### PR TITLE
Update paths to use `absolute` & add `flex-wrap` as utility class & add `not-sr-only` class as reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     },
     "scripts": {
         "dev": "concurrently --prefix-colors=\"cyan,yellow\" \"npm run sass:watch\" \"npm run sass:comp\"",
-        "sass:watch": "sass --no-source-map ./src/sass-pire.scss:dist/styles.css --watch",
-        "sass:comp": "sass --no-source-map ./src/sass-pire.scss:dist/styles.min.css --watch --style=compressed",
+        "sass:watch": "sass --no-source-map --load-path=./src/ --load-path=./src/abstract --load-path=./src/development-utils --load-path=./src/functions --load-path=./src/helpers --load-path=./src/mixins --load-path=./src/utils ./src/sass-pire.scss:dist/styles.css --watch",
+        "sass:comp": "sass --no-source-map --load-path=./src/ --load-path=./src/abstract --load-path=./src/development-utils --load-path=./src/functions --load-path=./src/helpers --load-path=./src/mixins --load-path=./src/utils ./src/sass-pire.scss:dist/styles.min.css --watch --style=compressed",
         "upgrade": "ncu --upgrade",
         "lint": "npx stylelint ./src/**/*.scss",
         "cmt": "cz",

--- a/src/development-utils/_approximation-numbers.scss
+++ b/src/development-utils/_approximation-numbers.scss
@@ -69,8 +69,8 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../functions/global/cut-unit" as LibFunc;
-@use "../development-utils/toggle-error-message" as Error;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function approx($num, $digits: 3, $mode: round) {
     $node: 1;

--- a/src/development-utils/_approximation-numbers.scss
+++ b/src/development-utils/_approximation-numbers.scss
@@ -86,7 +86,7 @@
         @return Error.throw("The mode parameter of approx function must be in a string type.");
     }
 
-    @if not math.unitless($num) {
+    @if not unitless($num) {
         $num-unit: math.unit($num);
     }
 

--- a/src/development-utils/_error.scss
+++ b/src/development-utils/_error.scss
@@ -45,7 +45,7 @@
 // @return {String} - Returns the provided error message.
 
 @use "sass:meta";
-@use "../abstract/config" as Config;
+@use "abstract/config" as Config;
 
 @function err($message) {
     @if meta.type-of($message) != string {

--- a/src/development-utils/_toggle-error-message.scss
+++ b/src/development-utils/_toggle-error-message.scss
@@ -45,8 +45,8 @@
 // @return {String} - Returns the provided error message.
 
 @use "sass:meta";
-@use "../abstract/config" as Config;
-@use "./error" as Dev;
+@use "abstract/config" as Config;
+@use "development-utils/error" as Dev;
 
 @function toggle-error-message($error-msg) {
     @if meta.type-of($error-msg) != string {

--- a/src/functions/converters/_centimeter-to-inches.scss
+++ b/src/functions/converters/_centimeter-to-inches.scss
@@ -46,9 +46,9 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../global/cut-unit" as LibFunc;
-@use "../../development-utils/approximation-numbers" as Approx;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/approximation-numbers" as Approx;
+@use "development-utils/toggle-error-message" as Error;
 
 @function cm-to-in($cm-val) {
     @if meta.type-of($cm-val) != number {

--- a/src/functions/converters/_centimeter-to-pixel.scss
+++ b/src/functions/converters/_centimeter-to-pixel.scss
@@ -46,9 +46,9 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../global/cut-unit" as LibFunc;
-@use "../../development-utils/approximation-numbers" as Approx;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/approximation-numbers" as Approx;
+@use "development-utils/toggle-error-message" as Error;
 
 @function cm-to-px($cm-val) {
     @if meta.type-of($cm-val) != number {

--- a/src/functions/converters/_decimal-to-percentage.scss
+++ b/src/functions/converters/_decimal-to-percentage.scss
@@ -55,8 +55,8 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../global/cut-unit" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function dec-to-ptg($dec-value: 0) {
     @if meta.type-of($dec-value) != number {

--- a/src/functions/converters/_inches-to-centimeter.scss
+++ b/src/functions/converters/_inches-to-centimeter.scss
@@ -46,9 +46,9 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../global/cut-unit" as LibFunc;
-@use "../../development-utils/approximation-numbers" as Approx;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/approximation-numbers" as Approx;
+@use "development-utils/toggle-error-message" as Error;
 
 @function in-to-cm($inches-val) {
     @if meta.type-of($inches-val) != number {

--- a/src/functions/converters/_inches-to-px.scss
+++ b/src/functions/converters/_inches-to-px.scss
@@ -45,8 +45,8 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../global/cut-unit" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function in-to-px($inches-val) {
     @if meta.type-of($inches-val) != number {

--- a/src/functions/converters/_percentage-to-decimal.scss
+++ b/src/functions/converters/_percentage-to-decimal.scss
@@ -57,8 +57,8 @@
 @use "sass:meta";
 @use "sass:math";
 @use "sass:list";
-@use "../global/cut-unit" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function ptg-to-dec($ptg-value: 0%) {
     @if meta.type-of($ptg-value) != number {

--- a/src/functions/converters/_pixel-to-centimeter.scss
+++ b/src/functions/converters/_pixel-to-centimeter.scss
@@ -46,9 +46,9 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../global/cut-unit" as LibFunc;
-@use "../../development-utils/approximation-numbers" as Approx;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/approximation-numbers" as Approx;
+@use "development-utils/toggle-error-message" as Error;
 
 @function px-to-cm($px-val) {
     @if meta.type-of($px-val) != number {

--- a/src/functions/converters/_pixel-to-inches.scss
+++ b/src/functions/converters/_pixel-to-inches.scss
@@ -46,9 +46,9 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../global/cut-unit" as LibFunc;
-@use "../../development-utils/approximation-numbers" as Approx;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/approximation-numbers" as Approx;
+@use "development-utils/toggle-error-message" as Error;
 
 @function px-to-in($px-val) {
     @if meta.type-of($px-val) != number {

--- a/src/functions/converters/_pixel-to-rem.scss
+++ b/src/functions/converters/_pixel-to-rem.scss
@@ -47,10 +47,10 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../../abstract/config" as Config;
-@use "../global/cut-unit" as LibFunc;
-@use "../../development-utils/approximation-numbers" as Approx;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/config" as Config;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/approximation-numbers" as Approx;
+@use "development-utils/toggle-error-message" as Error;
 
 @function px-to-rem($px-val) {
     @if meta.type-of($px-val) != number {

--- a/src/functions/global/_clamped.scss
+++ b/src/functions/global/_clamped.scss
@@ -56,8 +56,8 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../converters/pixel-to-rem" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/converters/pixel-to-rem" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function clamped($min-px, $max-px, $min-breakpoint: 320px, $max-breakpoint: 1200px) {
     @if meta.type-of($min-px) != number or

--- a/src/functions/global/_cut-unit.scss
+++ b/src/functions/global/_cut-unit.scss
@@ -47,7 +47,7 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function cut-unit($num) {
     @if meta.type-of($num) != number {

--- a/src/functions/global/_cut-unit.scss
+++ b/src/functions/global/_cut-unit.scss
@@ -55,11 +55,11 @@
     }
 
     // stylelint-disable-next-line length-zero-no-unit
-    @if math.unit($num) == "" and not math.unitless($num) {
+    @if math.unit($num) == "" and not unitless($num) {
         @return Error.throw("The parameter dose not need a unit if it equals to zero.");
     }
 
-    @if meta.type-of($num) == number and not math.unitless($num) {
+    @if meta.type-of($num) == number and not unitless($num) {
         @return math.div($num, ($num * 0 + 1));
     }
 

--- a/src/functions/global/_get-half-number.scss
+++ b/src/functions/global/_get-half-number.scss
@@ -54,7 +54,7 @@
 @use "sass:math";
 @use "sass:string";
 @use "cut-unit" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function half($number) {
     @if meta.type-of($number) != number {
@@ -65,7 +65,7 @@
         @return 0;
     }
 
-    @if not math.unitless($number) {
+    @if not unitless($number) {
         $num-after-cut-unit: LibFunc.cut-unit($number);
         $unit-of-number: math.unit($number);
 

--- a/src/functions/global/_has-position.scss
+++ b/src/functions/global/_has-position.scss
@@ -45,7 +45,7 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function has-pos($val) {
     $position-values: (top, right, bottom, left) !default;

--- a/src/functions/global/_is-in-list.scss
+++ b/src/functions/global/_is-in-list.scss
@@ -59,8 +59,8 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../list/flatten-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/list/flatten-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function is-in-list($list-name, $value) {
     @if meta.type-of($list-name) != list {

--- a/src/functions/global/_sum.scss
+++ b/src/functions/global/_sum.scss
@@ -76,8 +76,8 @@
 @use "sass:meta";
 @use "sass:math";
 @use "sass:list";
-@use "../list/flatten-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/list/flatten-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function sum($args: ()) {
     @if meta.type-of($args) != list {

--- a/src/functions/global/_trim-end.scss
+++ b/src/functions/global/_trim-end.scss
@@ -49,7 +49,7 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:string";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function trim-end($str-value) {
     @if meta.type-of($str-value) != "string" {

--- a/src/functions/global/_trim-start.scss
+++ b/src/functions/global/_trim-start.scss
@@ -49,7 +49,7 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:string";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function trim-start($str-value) {
     @if meta.type-of($str-value) != "string" {

--- a/src/functions/global/_trim-string.scss
+++ b/src/functions/global/_trim-string.scss
@@ -48,7 +48,7 @@
 @use "sass:string";
 @use "./trim-start" as LibFunc1;
 @use "./trim-end" as LibFunc2;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 // stylelint-disable scss/at-rule-conditional-no-parentheses
 

--- a/src/functions/list/_flatten-list.scss
+++ b/src/functions/list/_flatten-list.scss
@@ -71,7 +71,7 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function flatten($list: ()) {
     @if meta.type-of($list) != list {

--- a/src/functions/list/_get-centered-element-list.scss
+++ b/src/functions/list/_get-centered-element-list.scss
@@ -59,8 +59,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "flatten-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/list/flatten-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function center-of-list($list: ()) {
     @if meta.type-of($list) != list {

--- a/src/functions/list/_get-first-element.scss
+++ b/src/functions/list/_get-first-element.scss
@@ -61,9 +61,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../abstract/global-variables" as var;
-@use "flatten-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "functions/list/flatten-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function get-first-from($list: ()) {
     @if meta.type-of($list) != list {

--- a/src/functions/list/_get-last-element.scss
+++ b/src/functions/list/_get-last-element.scss
@@ -60,9 +60,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../abstract/global-variables" as var;
-@use "flatten-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "functions/list/flatten-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function get-last-from($list: ()) {
     @if meta.type-of($list) != list {

--- a/src/functions/list/_merge.scss
+++ b/src/functions/list/_merge.scss
@@ -44,8 +44,8 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "./flatten-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/list/flatten-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function merge($lists...) {
     $merged-list: ();

--- a/src/functions/list/_reverse.scss
+++ b/src/functions/list/_reverse.scss
@@ -49,8 +49,8 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "flatten-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/list/flatten-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function reverse($list: ()) {
     @if meta.type-of($list) != list {

--- a/src/functions/map/_has-same-keys.scss
+++ b/src/functions/map/_has-same-keys.scss
@@ -45,7 +45,7 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:map";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function has-same-keys($all-maps...) {
     $keys-list: null;

--- a/src/functions/type-checks/_has-absolute-units.scss
+++ b/src/functions/type-checks/_has-absolute-units.scss
@@ -47,7 +47,7 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function has-abs-unit($value) {
     @if meta.type-of($value) != number {

--- a/src/functions/type-checks/_has-percentage.scss
+++ b/src/functions/type-checks/_has-percentage.scss
@@ -44,7 +44,7 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function has-ptg($value) {
     @if meta.type-of($value) != number {

--- a/src/functions/type-checks/_has-relative-units.scss
+++ b/src/functions/type-checks/_has-relative-units.scss
@@ -47,7 +47,7 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function has-rel-unit($value) {
     @if meta.type-of($value) != number {

--- a/src/functions/type-checks/_has-resolution-units.scss
+++ b/src/functions/type-checks/_has-resolution-units.scss
@@ -46,7 +46,7 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function has-res-unit($value) {
     @if meta.type-of($value) != number {

--- a/src/functions/type-checks/_has-viewport-units.scss
+++ b/src/functions/type-checks/_has-viewport-units.scss
@@ -47,7 +47,7 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @function has-view-unit($value) {
     @if meta.type-of($value) != number {

--- a/src/functions/type-checks/_is-angle.scss
+++ b/src/functions/type-checks/_is-angle.scss
@@ -48,8 +48,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @function is-angle($value) {
     @if meta.type-of($value) != number {

--- a/src/functions/type-checks/_is-float.scss
+++ b/src/functions/type-checks/_is-float.scss
@@ -47,8 +47,8 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../global/cut-unit" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function is-float($value) {
     @if meta.type-of($value) != number {

--- a/src/functions/type-checks/_is-integer.scss
+++ b/src/functions/type-checks/_is-integer.scss
@@ -45,8 +45,8 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../global/cut-unit" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/cut-unit" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @function is-int($value) {
     @if meta.type-of($value) != number {

--- a/src/functions/type-checks/_is-time.scss
+++ b/src/functions/type-checks/_is-time.scss
@@ -48,8 +48,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @function is-time($value) {
     @if meta.type-of($value) != number {

--- a/src/mixins/flex-props/flexbox/_around.scss
+++ b/src/mixins/flex-props/flexbox/_around.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-around-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_between.scss
+++ b/src/mixins/flex-props/flexbox/_between.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-between-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_center.scss
+++ b/src/mixins/flex-props/flexbox/_center.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-center-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_end.scss
+++ b/src/mixins/flex-props/flexbox/_end.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-end-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_evenly.scss
+++ b/src/mixins/flex-props/flexbox/_evenly.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-even-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_fend.scss
+++ b/src/mixins/flex-props/flexbox/_fend.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-fend-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_fstart.scss
+++ b/src/mixins/flex-props/flexbox/_fstart.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-fstart-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_inherit.scss
+++ b/src/mixins/flex-props/flexbox/_inherit.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-inh-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_left.scss
+++ b/src/mixins/flex-props/flexbox/_left.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-left-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_normal.scss
+++ b/src/mixins/flex-props/flexbox/_normal.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-normal-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_right.scss
+++ b/src/mixins/flex-props/flexbox/_right.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-right-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_start.scss
+++ b/src/mixins/flex-props/flexbox/_start.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-start-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/flexbox/_stretch.scss
+++ b/src/mixins/flex-props/flexbox/_stretch.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/flex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/flex-prop" as LibMixin;
 
 // @mixin flex-stretch-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-around.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-around.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-around-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-between.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-between.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-between-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-center.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-center.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-center-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-end.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-end.scss
@@ -56,7 +56,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-end-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-evenly.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-evenly.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-even-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-fend.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-fend.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-fend-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-fstart.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-fstart.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-fstart-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-inherit.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-inherit.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-inh-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-left.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-left.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-left-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-normal.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-normal.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-normal-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-right.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-right.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-right-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-start.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-start.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-start-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/inline-flexbox/_in-stretch.scss
+++ b/src/mixins/flex-props/inline-flexbox/_in-stretch.scss
@@ -57,7 +57,7 @@
 // *   align-items: normal;
 // * }
 
-@use "../main-props/inflex-prop" as LibMixin;
+@use "mixins/flex-props/main-props/inflex-prop" as LibMixin;
 
 // @mixin inflex-stretch-normal
 // @param {String} $dir - The flex direction. Default: row.

--- a/src/mixins/flex-props/main-props/_align-items.scss
+++ b/src/mixins/flex-props/main-props/_align-items.scss
@@ -58,9 +58,9 @@
 // * The core logic of (a-i) mixin is to call the first one.
 // * You can use one of them as you want.
 
-@use "../../../abstract/global-variables" as var;
-@use "../../../development-utils/toggle-error-message" as Error;
-@use "../../../functions/global/is-in-list" as LibFunc;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc;
 
 @mixin align-items($value: normal) {
     @if LibFunc.is-in-list(var.$align-items-values, $value) {

--- a/src/mixins/flex-props/main-props/_align-self.scss
+++ b/src/mixins/flex-props/main-props/_align-self.scss
@@ -59,8 +59,8 @@
 // * You can use one of them as you want.
 
 @use "sass:meta";
-@use "../../../functions/global/is-in-list" as LibFunc;
-@use "../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin align-self($value: auto) {
     $align-self-props: (

--- a/src/mixins/flex-props/main-props/_flex-basis.scss
+++ b/src/mixins/flex-props/main-props/_flex-basis.scss
@@ -65,8 +65,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../../functions/global" as LibFunc;
-@use "../../../development-utils/toggle-error-message" as Error;
+@use "functions/global" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin flex-basis($value: auto) {
     $flex-basis-props: (

--- a/src/mixins/flex-props/main-props/_flex-direction.scss
+++ b/src/mixins/flex-props/main-props/_flex-direction.scss
@@ -61,8 +61,8 @@
 // stylelint-disable scss/dollar-variable-empty-line-before
 // stylelint-disable scss/no-global-function-names
 
-@use "../../../functions/global/is-in-list" as LibFunc;
-@use "../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin flex-dir($value: row) {
     $flex-direction-values: (row, r, row-reverse, r-rev, column, col, c, column-reverse, col-rev, "") !default;

--- a/src/mixins/flex-props/main-props/_flex-flow.scss
+++ b/src/mixins/flex-props/main-props/_flex-flow.scss
@@ -50,8 +50,8 @@
 // *   flex-wrap: nowrap;
 // * }
 
-@use "./flex-direction" as LibMixin1;
-@use "./flex-wrap" as LibMixin2;
+@use "mixins/flex-props/main-props/flex-direction" as LibMixin1;
+@use "mixins/flex-props/main-props/flex-wrap" as LibMixin2;
 
 @mixin flow($flex-dir-value: row, $flex-wrap-value: nowrap) {
     @include LibMixin1.flex-dir($flex-dir-value);

--- a/src/mixins/flex-props/main-props/_flex-grow.scss
+++ b/src/mixins/flex-props/main-props/_flex-grow.scss
@@ -56,7 +56,7 @@
 // * You can use one of them as you want.
 
 @use "sass:meta";
-@use "../../../functions/global/cut-unit" as LibFunc;
+@use "functions/global/cut-unit" as LibFunc;
 
 @mixin flex-grow($value: 0) {
     $flex-grow-props: (-webkit-flex-grow, -webkit-box-flex, -ms-flex-positive, -moz-box-flex, flex-grow) !default;

--- a/src/mixins/flex-props/main-props/_flex-prop.scss
+++ b/src/mixins/flex-props/main-props/_flex-prop.scss
@@ -80,10 +80,10 @@
 // *   align-items: center;
 // * }
 
-@use "flex" as f;
-@use "flex-direction" as dir;
-@use "justify-content" as jc;
-@use "align-items" as ai;
+@use "mixins/flex-props/main-props/flex" as f;
+@use "mixins/flex-props/main-props/flex-direction" as dir;
+@use "mixins/flex-props/main-props/justify-content" as jc;
+@use "mixins/flex-props/main-props/align-items" as ai;
 
 @mixin f-prop($f-dir: row, $justify-content-val: flex-start, $align-items-val: normal) {
     @include f.d-flex;

--- a/src/mixins/flex-props/main-props/_flex-shrink.scss
+++ b/src/mixins/flex-props/main-props/_flex-shrink.scss
@@ -61,8 +61,8 @@
 // stylelint-disable scss/dollar-variable-empty-line-before
 
 @use "sass:meta";
-@use "../../../functions/global" as LibFunc;
-@use "../../../development-utils/toggle-error-message" as Error;
+@use "functions/global" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin flex-shrink($value) {
     $flex-shrink-props: (

--- a/src/mixins/flex-props/main-props/_flex-wrap.scss
+++ b/src/mixins/flex-props/main-props/_flex-wrap.scss
@@ -60,9 +60,9 @@
 // stylelint-disable scss/dollar-variable-empty-line-before
 
 @use "sass:map";
-@use "../../vendor-prefixes/prefix" as LibMixin;
-@use "../../../functions/global/is-in-list" as LibFunc;
-@use "../../../development-utils/toggle-error-message" as Error;
+@use "mixins/vendor-prefixes/prefix" as LibMixin;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin flex-wrap($value: nowrap) {
     $flex-wrap-values: (nowrap, wrap, wrap-reverse, "", no, yes, w, wrap-rev, w-rev, inherit) !default;

--- a/src/mixins/flex-props/main-props/_inflex-prop.scss
+++ b/src/mixins/flex-props/main-props/_inflex-prop.scss
@@ -68,10 +68,10 @@
 // *   align-items: center;
 // * }
 
-@use "../main-props/inline-flex" as f;
-@use "../main-props/flex-direction" as dir;
-@use "../main-props/justify-content" as jc;
-@use "../main-props/align-items" as ai;
+@use "mixins/flex-props/main-props/inline-flex" as f;
+@use "mixins/flex-props/main-props/flex-direction" as dir;
+@use "mixins/flex-props/main-props/justify-content" as jc;
+@use "mixins/flex-props/main-props/align-items" as ai;
 
 @mixin inflex-prop($f-dir: row, $justify-content-val: flex-start, $align-items-val: normal) {
     @include f.d-inflex;

--- a/src/mixins/flex-props/main-props/_justify-content.scss
+++ b/src/mixins/flex-props/main-props/_justify-content.scss
@@ -55,9 +55,9 @@
 // * The core logic of (j-c) mixin is to call the first one.
 // * You can use one of them as you want.
 
-@use "../../../abstract/global-variables" as var;
-@use "../../../functions/global/is-in-list" as LibFunc;
-@use "../../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin justify-content($value: flex-start) {
     @if LibFunc.is-in-list(var.$justify-content-values, $value) {

--- a/src/mixins/flex-props/main-props/_order.scss
+++ b/src/mixins/flex-props/main-props/_order.scss
@@ -50,7 +50,7 @@
 // * }
 
 @use "sass:meta";
-@use "../../../functions/global/cut-unit" as LibFunc;
+@use "functions/global/cut-unit" as LibFunc;
 
 @mixin order($value: 0) {
     $order-props: (

--- a/src/mixins/general/_banner.scss
+++ b/src/mixins/general/_banner.scss
@@ -37,7 +37,7 @@
 
 // stylelint-disable comment-empty-line-before
 
-@use "../../abstract/settings" as Settings;
+@use "abstract/settings" as Settings;
 
 @mixin banner() {
     /*

--- a/src/mixins/general/_banner.scss
+++ b/src/mixins/general/_banner.scss
@@ -30,7 +30,7 @@
 
 // @note:
 // * In your ~/base/reset.scss file, include the following line at the top:
-// * @use "../abstract/variables" as var;
+// * @use "abstract/variables" as var;
 // * @include banner();
 // * This will insert the library banner at the beginning of
 // * the compiled CSS file.

--- a/src/mixins/general/_box-shadow.scss
+++ b/src/mixins/general/_box-shadow.scss
@@ -71,8 +71,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../vendor-prefixes/prefix" as pref;
-@use "../../abstract/global-variables" as var;
+@use "mixins/vendor-prefixes/prefix" as pref;
+@use "abstract/global-variables" as var;
 
 @mixin shadow($val...) {
     $box-shadow-values: (inherit, initial, revert, revert-layer, unset, none) !default;

--- a/src/mixins/general/_circle.scss
+++ b/src/mixins/general/_circle.scss
@@ -50,8 +50,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin circle($one-side: 0) {
     @if meta.type-of($one-side) != number {

--- a/src/mixins/general/_color-generator-dark-mode.scss
+++ b/src/mixins/general/_color-generator-dark-mode.scss
@@ -124,7 +124,7 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:map";
-@use "../../functions/map/has-same-keys" as func;
+@use "functions/map/has-same-keys" as func;
 
 @mixin generate-colors-dark-mode($light-colors-map: (), $dark-colors-map: (), $generate-with-attr: false) {
     @if meta.type-of($light-colors-map) != map {

--- a/src/mixins/general/_color-generator-vars.scss
+++ b/src/mixins/general/_color-generator-vars.scss
@@ -77,7 +77,7 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:string";
-@use "../../abstract/settings" as Settings;
+@use "abstract/settings" as Settings;
 
 @mixin generate-colors($brand-name: Settings.$brand-lib-name, $color-map: ()) {
     @if meta.type-of($brand-name) != string {

--- a/src/mixins/general/_fade.scss
+++ b/src/mixins/general/_fade.scss
@@ -41,7 +41,7 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin fade($type: show) {
     @if meta.type-of($type) != string {

--- a/src/mixins/general/_object-fit.scss
+++ b/src/mixins/general/_object-fit.scss
@@ -38,8 +38,8 @@
 // * }
 
 @use "sass:meta";
-@use "../../functions/global/is-in-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin object-fit($value: fill) {
     @if meta.type-of($value) != string {

--- a/src/mixins/general/_overscroll-behavior.scss
+++ b/src/mixins/general/_overscroll-behavior.scss
@@ -43,8 +43,8 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin overscroll($value: auto) {
     @if meta.type-of($value) != string {

--- a/src/mixins/general/_reset.scss
+++ b/src/mixins/general/_reset.scss
@@ -346,6 +346,3 @@
         white-space: normal;
     }
 }
-
-
-@include reset;

--- a/src/mixins/general/_reset.scss
+++ b/src/mixins/general/_reset.scss
@@ -328,4 +328,24 @@
         overflow: hidden;
         white-space: nowrap;
     }
+
+    /* This is for accessibility purposes */
+    .not-sr-only {
+        --sp-not-sr-only-width: auto;
+        --sp-not-sr-only-height: auto;
+
+        inline-size: var(--sp-not-sr-only-width);
+        width: var(--sp-not-sr-only-width);
+        block-size: var(--sp-not-sr-only-height);
+        height: var(--sp-not-sr-only-height);
+        position: static;
+        padding: 0;
+        margin: 0;
+        overflow: visible;
+        clip: auto;
+        white-space: normal;
+    }
 }
+
+
+@include reset;

--- a/src/mixins/general/_reset.scss
+++ b/src/mixins/general/_reset.scss
@@ -40,9 +40,9 @@
 // @example 3
 // * You can use it whatever you want.
 
-@use "../../mixins/vendor-prefixes/prefix" as LibMixin1;
-@use "../../mixins/general/shape-margin" as LibMixin2;
-@use "../../mixins/general/banner" as LibMixin3;
+@use "mixins/vendor-prefixes/prefix" as LibMixin1;
+@use "mixins/general/shape-margin" as LibMixin2;
+@use "mixins/general/banner" as LibMixin3;
 
 // * stylelint-disable-next-line at-rule-empty-line-before
 

--- a/src/mixins/general/_reset.scss
+++ b/src/mixins/general/_reset.scss
@@ -326,5 +326,6 @@
         position: absolute;
         clip: rect(0, 0, 0, 0);
         overflow: hidden;
+        white-space: nowrap;
     }
 }

--- a/src/mixins/general/_responsive-grid.scss
+++ b/src/mixins/general/_responsive-grid.scss
@@ -48,9 +48,9 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../functions/global/is-in-list" as LibFunc;
-@use "../vendor-prefixes/prefix-val" as LibPref;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc;
+@use "mixins/vendor-prefixes/prefix-val" as LibPref;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin grid($min-col-size: 4rem, $gap: 1rem) {
     @if meta.type-of($min-col-size) != number {

--- a/src/mixins/general/_shape-margin.scss
+++ b/src/mixins/general/_shape-margin.scss
@@ -43,8 +43,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin shape-margin($value: 0) {
     @if meta.type-of($value) != number {

--- a/src/mixins/general/_square.scss
+++ b/src/mixins/general/_square.scss
@@ -49,13 +49,13 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../functions/global/is-in-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin square($one-side: 1px) {
     @if meta.type-of($one-side) == number {
-        @if not math.unitless($one-side) {
+        @if not unitless($one-side) {
             @if LibFunc.is-in-list(var.$all-units, math.unit($one-side)) {
                 --sp-one-side: #{$one-side};
 

--- a/src/mixins/general/_transition.scss
+++ b/src/mixins/general/_transition.scss
@@ -58,11 +58,11 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../vendor-prefixes/prefix" as LibPref;
-@use "../../functions/global/is-in-list" as LibFunc1;
-@use "../../functions/global/cut-unit" as LibFunc2;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "mixins/vendor-prefixes/prefix" as LibPref;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/global/cut-unit" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin transition($prop: all, $time: 0.33ms, $func: ease-in-out, $delaying: 0ms) {
     $time-unit: math.unit($time);

--- a/src/mixins/general/_user-select.scss
+++ b/src/mixins/general/_user-select.scss
@@ -53,8 +53,8 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../functions/global/is-in-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin u-select($value: auto) {
     $user-select-props: (-webkit-user-select, -moz-user-select, -ms-user-select, user-select) !default;

--- a/src/mixins/grid-props/_column-gap.scss
+++ b/src/mixins/grid-props/_column-gap.scss
@@ -45,8 +45,8 @@
 
 @use "sass:meta";
 @use "sass:math";
-@use "../../functions/global/is-in-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin col-gap($value) {
     $column-gap-prefixes-values: (-webkit-column-gap, -moz-column-gap, column-gap) !default;
@@ -64,7 +64,7 @@
             );
         }
     } @else if meta.type-of($value) == number {
-        @if not math.unitless($value) {
+        @if not unitless($value) {
             @each $one-item in $column-gap-prefixes-values {
                 #{$one-item}: #{$value};
             }

--- a/src/mixins/grid-props/_grid-area.scss
+++ b/src/mixins/grid-props/_grid-area.scss
@@ -41,7 +41,7 @@
 // * }
 
 @use "sass:meta";
-@use "../../development-utils/toggle-error-message" as Error;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin area($value) {
     @if meta.type-of($value) != string {

--- a/src/mixins/grid-props/_grid-column.scss
+++ b/src/mixins/grid-props/_grid-column.scss
@@ -49,8 +49,8 @@
 @use "sass:meta";
 @use "sass:string";
 @use "sass:list";
-@use "../../functions/global/trim-string" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/trim-string" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 // stylelint-disable property-no-vendor-prefix
 

--- a/src/mixins/logical-props/_margin-block-end.scss
+++ b/src/mixins/logical-props/_margin-block-end.scss
@@ -40,8 +40,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin mbe($value: 0) {
     @if meta.type-of($value) != number {

--- a/src/mixins/logical-props/_margin-block-start.scss
+++ b/src/mixins/logical-props/_margin-block-start.scss
@@ -40,8 +40,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin mbs($value: 0) {
     @if meta.type-of($value) != number {

--- a/src/mixins/logical-props/_margin-inline-end.scss
+++ b/src/mixins/logical-props/_margin-inline-end.scss
@@ -40,8 +40,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin mie($value: 0) {
     @if meta.type-of($value) != number {

--- a/src/mixins/logical-props/_margin-inline-start.scss
+++ b/src/mixins/logical-props/_margin-inline-start.scss
@@ -40,8 +40,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin mis($value: 0) {
     @if meta.type-of($value) != number {

--- a/src/mixins/logical-props/_overflow-x.scss
+++ b/src/mixins/logical-props/_overflow-x.scss
@@ -39,8 +39,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin overflow-x($value: visible) {
     @if meta.type-of($value) != string {

--- a/src/mixins/logical-props/_overflow-y.scss
+++ b/src/mixins/logical-props/_overflow-y.scss
@@ -39,8 +39,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin overflow-y($value: visible) {
     @if meta.type-of($value) != string {

--- a/src/mixins/logical-props/_padding-block-end.scss
+++ b/src/mixins/logical-props/_padding-block-end.scss
@@ -40,8 +40,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin pbe($value: 0) {
     @if meta.type-of($value) != number {

--- a/src/mixins/logical-props/_padding-block-start.scss
+++ b/src/mixins/logical-props/_padding-block-start.scss
@@ -40,8 +40,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin pbs($value: 0) {
     @if meta.type-of($value) != number {

--- a/src/mixins/logical-props/_padding-inline-end.scss
+++ b/src/mixins/logical-props/_padding-inline-end.scss
@@ -40,8 +40,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin pie($value: 0) {
     @if meta.type-of($value) != number {

--- a/src/mixins/logical-props/_padding-inline-start.scss
+++ b/src/mixins/logical-props/_padding-inline-start.scss
@@ -40,8 +40,8 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin pis($value: 0) {
     @if meta.type-of($value) != number {

--- a/src/mixins/media-queries/screens/_media-query.scss
+++ b/src/mixins/media-queries/screens/_media-query.scss
@@ -60,8 +60,8 @@
 
 @use "sass:list";
 @use "sass:map";
-@use "../../../functions/global/is-in-list" as LibFunc;
-@use "../../../development-utils//toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils//toggle-error-message" as Error;
 
 @mixin mq-general($type: min, $dimension: w, $breakpoint-name: md) {
     $main-mq-types: (min, max) !default;

--- a/src/mixins/media-queries/screens/laptops/_laptop-general.scss
+++ b/src/mixins/media-queries/screens/laptops/_laptop-general.scss
@@ -69,9 +69,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../functions/list/merge" as LibFunc2;
-@use "../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin laptop-general($retina-value) {
     @if meta.type-of($retina-value) != string {

--- a/src/mixins/media-queries/screens/phones/HTC/_htc-1.scss
+++ b/src/mixins/media-queries/screens/phones/HTC/_htc-1.scss
@@ -57,9 +57,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin htc-1($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/galaxy/_galaxy-med.scss
+++ b/src/mixins/media-queries/screens/phones/galaxy/_galaxy-med.scss
@@ -70,9 +70,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin galaxy-med($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/galaxy/_galaxy-s3.scss
+++ b/src/mixins/media-queries/screens/phones/galaxy/_galaxy-s3.scss
@@ -69,9 +69,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin galaxy-s3($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/galaxy/_galaxy-s6.scss
+++ b/src/mixins/media-queries/screens/phones/galaxy/_galaxy-s6.scss
@@ -69,9 +69,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin galaxy-s6($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/google/_google-pixel-xl.scss
+++ b/src/mixins/media-queries/screens/phones/google/_google-pixel-xl.scss
@@ -69,9 +69,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin google-pixel-xl($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/google/_google-pixel.scss
+++ b/src/mixins/media-queries/screens/phones/google/_google-pixel.scss
@@ -69,9 +69,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin google-pixel($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/iphone/_iphone-5.scss
+++ b/src/mixins/media-queries/screens/phones/iphone/_iphone-5.scss
@@ -75,12 +75,13 @@
 
 // stylelint-disable media-feature-name-no-vendor-prefix
 // stylelint-disable scss/operator-no-newline-after
+// stylelint-disable media-query-no-invalid
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin iphone-5($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/iphone/_iphone-6-plus.scss
+++ b/src/mixins/media-queries/screens/phones/iphone/_iphone-6-plus.scss
@@ -65,10 +65,11 @@
 
 // stylelint-disable media-feature-name-no-vendor-prefix
 // stylelint-disable scss/operator-no-newline-after
+// stylelint-disable media-query-no-invalid
 
 @use "sass:meta";
-@use "../../../../../functions/global/is-in-list" as LibFunc;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin iphone-6p($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/iphone/_iphone-6.scss
+++ b/src/mixins/media-queries/screens/phones/iphone/_iphone-6.scss
@@ -72,12 +72,13 @@
 
 // stylelint-disable media-feature-name-no-vendor-prefix
 // stylelint-disable scss/operator-no-newline-after
+// stylelint-disable media-query-no-invalid
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin iphone-6($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/iphone/_iphone-7-plus.scss
+++ b/src/mixins/media-queries/screens/phones/iphone/_iphone-7-plus.scss
@@ -69,9 +69,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin iphone-7p($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/iphone/_iphone-7.scss
+++ b/src/mixins/media-queries/screens/phones/iphone/_iphone-7.scss
@@ -69,9 +69,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin iphone-7($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/iphone/_iphone-8-plus.scss
+++ b/src/mixins/media-queries/screens/phones/iphone/_iphone-8-plus.scss
@@ -69,9 +69,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin iphone-8p($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/iphone/_iphone-8.scss
+++ b/src/mixins/media-queries/screens/phones/iphone/_iphone-8.scss
@@ -76,9 +76,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin iphone-8($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/iphone/_iphone-x.scss
+++ b/src/mixins/media-queries/screens/phones/iphone/_iphone-x.scss
@@ -64,9 +64,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin iphone-x($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/iphone/_iphone.scss
+++ b/src/mixins/media-queries/screens/phones/iphone/_iphone.scss
@@ -69,9 +69,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin iphone($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/nexus/_nexus-4.scss
+++ b/src/mixins/media-queries/screens/phones/nexus/_nexus-4.scss
@@ -57,9 +57,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin nx-4($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/nexus/_nexus-5.scss
+++ b/src/mixins/media-queries/screens/phones/nexus/_nexus-5.scss
@@ -57,9 +57,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin nx-5($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/nexus/_nexus-6.scss
+++ b/src/mixins/media-queries/screens/phones/nexus/_nexus-6.scss
@@ -57,9 +57,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin nx-6($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/phones/windows/_windows-phone.scss
+++ b/src/mixins/media-queries/screens/phones/windows/_windows-phone.scss
@@ -68,9 +68,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin windows-phone($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/tablets/ipad/_ipad-med.scss
+++ b/src/mixins/media-queries/screens/tablets/ipad/_ipad-med.scss
@@ -60,9 +60,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin ipad-med($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/tablets/ipad/_ipad-mini.scss
+++ b/src/mixins/media-queries/screens/tablets/ipad/_ipad-mini.scss
@@ -60,9 +60,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin ipad-mini($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/tablets/ipad/_ipad-pro-10.scss
+++ b/src/mixins/media-queries/screens/tablets/ipad/_ipad-pro-10.scss
@@ -74,9 +74,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin ipad-pro-10($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/media-queries/screens/tablets/ipad/_ipad-pro-12.scss
+++ b/src/mixins/media-queries/screens/tablets/ipad/_ipad-pro-12.scss
@@ -74,9 +74,9 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../../../../functions/global/is-in-list" as LibFunc1;
-@use "../../../../../functions/list/merge" as LibFunc2;
-@use "../../../../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc1;
+@use "functions/list/merge" as LibFunc2;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin ipad-pro-12($orientation-type: portrait) {
     @if meta.type-of($orientation-type) != string {

--- a/src/mixins/transform/_rotate-x.scss
+++ b/src/mixins/transform/_rotate-x.scss
@@ -53,9 +53,9 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../vendor-prefixes/prefix" as LibMixin;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "mixins/vendor-prefixes/prefix" as LibMixin;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin rotate-x($angle: 0deg) {
     $transform-props-values: (inherit, initial, revert, unset, none) !default;

--- a/src/mixins/transform/_rotate-y.scss
+++ b/src/mixins/transform/_rotate-y.scss
@@ -53,9 +53,9 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../vendor-prefixes/prefix" as LibMixin;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "mixins/vendor-prefixes/prefix" as LibMixin;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin rotate-y($angle: 0deg) {
     $transform-props-values: (inherit, initial, revert, unset, none) !default;

--- a/src/mixins/transform/_rotate.scss
+++ b/src/mixins/transform/_rotate.scss
@@ -53,9 +53,9 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../vendor-prefixes/prefix" as LibMixin;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "mixins/vendor-prefixes/prefix" as LibMixin;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin rotate($val: 0deg) {
     $transform-props-values: (inherit, initial, revert, unset, none) !default;

--- a/src/mixins/transform/_scale.scss
+++ b/src/mixins/transform/_scale.scss
@@ -58,9 +58,9 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../vendor-prefixes/prefix" as LibMixin;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "mixins/vendor-prefixes/prefix" as LibMixin;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin scale($x: 1px, $y: $x) {
     $transform-props-values: (inherit, initial, revert, unset, none) !default;

--- a/src/mixins/transform/_translate-x.scss
+++ b/src/mixins/transform/_translate-x.scss
@@ -54,9 +54,9 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../vendor-prefixes/prefix" as LibMixin;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "mixins/vendor-prefixes/prefix" as LibMixin;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin translate-x($x: 1px) {
     $transform-props-values: (inherit, initial, revert, unset, none) !default;

--- a/src/mixins/transform/_translate-y.scss
+++ b/src/mixins/transform/_translate-y.scss
@@ -54,9 +54,9 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../vendor-prefixes/prefix" as LibMixin;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "mixins/vendor-prefixes/prefix" as LibMixin;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin translate-y($y: 1px) {
     $transform-props-values: (inherit, initial, revert, unset, none) !default;

--- a/src/mixins/transform/_translate.scss
+++ b/src/mixins/transform/_translate.scss
@@ -61,9 +61,9 @@
 @use "sass:meta";
 @use "sass:list";
 @use "sass:math";
-@use "../../abstract/global-variables" as var;
-@use "../vendor-prefixes/prefix" as LibMixin;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "abstract/global-variables" as var;
+@use "mixins/vendor-prefixes/prefix" as LibMixin;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin translate($x: 1px, $y: $x) {
     $transform-props-values: (inherit, initial, revert, unset, none) !default;

--- a/src/mixins/typography/_line-text-truncation.scss
+++ b/src/mixins/typography/_line-text-truncation.scss
@@ -61,8 +61,8 @@
 // * }
 
 @use "sass:meta";
-@use "./text-overflow" as LibMixin;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "mixins/typography/text-overflow" as LibMixin;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin line-text-trunc($lines: 1) {
     @if meta.type-of($lines) != number {

--- a/src/mixins/typography/_text-align-last.scss
+++ b/src/mixins/typography/_text-align-last.scss
@@ -46,8 +46,8 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../functions/global/is-in-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin text-align-last($value: auto) {
     $text-align-last-props: (

--- a/src/mixins/typography/_text-overflow.scss
+++ b/src/mixins/typography/_text-overflow.scss
@@ -44,8 +44,8 @@
 
 @use "sass:meta";
 @use "sass:list";
-@use "../../functions/global/is-in-list" as LibFunc;
-@use "../../development-utils/toggle-error-message" as Error;
+@use "functions/global/is-in-list" as LibFunc;
+@use "development-utils/toggle-error-message" as Error;
 
 @mixin text-overflow($value: clip) {
     $text-overflow-props: (

--- a/src/utils/flexbox/_align-items.scss
+++ b/src/utils/flexbox/_align-items.scss
@@ -35,8 +35,8 @@
 // *   align-items: center;
 // * }
 
-@use "../../abstract/global-variables" as var;
-@use "../../mixins/flex-props/main-props/align-items" as LibMixin;
+@use "abstract/global-variables" as var;
+@use "mixins/flex-props/main-props/align-items" as LibMixin;
 
 @each $value in var.$align-items-values {
     .u-ai-#{$value} {

--- a/src/utils/flexbox/_flex-direction.scss
+++ b/src/utils/flexbox/_flex-direction.scss
@@ -36,7 +36,7 @@
 // *   flex-direction: column;
 // * }
 
-@use "../../mixins/flex-props/main-props/flex-direction" as LibMixin;
+@use "mixins/flex-props/main-props/flex-direction" as LibMixin;
 
 $flex-direction-values: (
     flex-row: row,

--- a/src/utils/flexbox/_flex-wrap.scss
+++ b/src/utils/flexbox/_flex-wrap.scss
@@ -1,0 +1,45 @@
+@charset "UTF-8";
+
+// @description
+// * flex-wrap utility class.
+// * It can be used as a standalone class in any where it is needed.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace utils
+
+// @module utils/flex-wrap
+
+// @dependencies:
+// * - LibMixin.flex-wrap (mixin).
+
+// @example
+// * <div class="u-flex-nowrap"></div>
+
+// @output:
+// * .u-flex-nowrap {
+// *   -ms-flex-wrap: nowrap;
+// *   flex-wrap: nowrap;
+// * }
+
+@use "mixins/flex-props/main-props/flex-wrap" as LibMixin;
+
+$flex-wrap-values: (
+    flex-wrap: wrap,
+    flex-wrap-reverse: wrap-reverse,
+    flex-nowrap: nowrap
+);
+
+@each $flex-wrap-class-name, $flex-wrap-value in $flex-wrap-values {
+    .u-#{$flex-wrap-class-name} {
+        @include LibMixin.flex-wrap($flex-wrap-value);
+    }
+}

--- a/src/utils/flexbox/_index.scss
+++ b/src/utils/flexbox/_index.scss
@@ -26,3 +26,8 @@
 // * This module likely contains flex-direction as class.
 // @see flex-direction
 @forward "flex-direction";
+
+// * forwarding the "flex-wrap" module.
+// * This module likely contains flex-wrap as class.
+// @see flex-wrap
+@forward "flex-wrap";

--- a/src/utils/flexbox/_justify-content.scss
+++ b/src/utils/flexbox/_justify-content.scss
@@ -35,8 +35,8 @@
 // *   justify-content: center;
 // * }
 
-@use "../../abstract/global-variables" as var;
-@use "../../mixins/flex-props/main-props/justify-content" as LibMixin;
+@use "abstract/global-variables" as var;
+@use "mixins/flex-props/main-props/justify-content" as LibMixin;
 
 @each $value in var.$justify-content-values {
     .u-jc-#{$value} {

--- a/src/utils/layout/_display.scss
+++ b/src/utils/layout/_display.scss
@@ -49,10 +49,10 @@
 // * We separated (flex & grid) from the $display-values map
 // * because of the vendor prefixes of them.
 
-@use "../../mixins/flex-props/main-props/flex" as LibMixin1;
-@use "../../mixins/flex-props/main-props/inline-flex" as LibMixin2;
-@use "../../mixins/grid-props/grid" as LibMixin3;
-@use "../../mixins/grid-props/inline-grid" as LibMixin4;
+@use "mixins/flex-props/main-props/flex" as LibMixin1;
+@use "mixins/flex-props/main-props/inline-flex" as LibMixin2;
+@use "mixins/grid-props/grid" as LibMixin3;
+@use "mixins/grid-props/inline-grid" as LibMixin4;
 
 $display-values: (
     block: block,

--- a/src/utils/layout/_object-fit.scss
+++ b/src/utils/layout/_object-fit.scss
@@ -40,7 +40,7 @@
 // *   object-fit: fill;
 // * }
 
-@use "../../mixins/general/object-fit" as LibMixin;
+@use "mixins/general/object-fit" as LibMixin;
 
 $object-fit-values: (
     object-contain: contain,

--- a/src/utils/layout/_overscroll.scss
+++ b/src/utils/layout/_overscroll.scss
@@ -42,7 +42,7 @@
 // * }
 
 @use "sass:list";
-@use "../../mixins/general/overscroll-behavior" as LibMixin;
+@use "mixins/general/overscroll-behavior" as LibMixin;
 
 $overscroll-values: (
     overscroll-auto: (overscroll-behavior, auto),

--- a/src/utils/typography/_text-overflow.scss
+++ b/src/utils/typography/_text-overflow.scss
@@ -40,7 +40,7 @@
 // *   text-overflow: clip;
 // * }
 
-@use "../../mixins/typography/text-overflow" as LibMixin;
+@use "mixins/typography/text-overflow" as LibMixin;
 
 $text-overflow-values: (
     text-clip: clip,


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `flex-wrap` as utility classes.
- Update the command line script in `package.json` file
- Update paths in all files of `sass-pire` library to use `absolute` path.
- Add `not-sr-only` class in `reset` mixin.
- Update properties in the `sr-only` class by adding the `white-space` CSS property and assign `nowrap` to it.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
