### PR TITLE
Add some useful mixin for select children element

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,7 +41,8 @@
         "security",
         "mixins-logical-props",
         "settings",
-        "mixins-typo"
+        "mixins-typo",
+        "mixins-children"
     ],
     "cSpell.words": ["Giraudel"]
 }

--- a/src/mixins/_index.scss
+++ b/src/mixins/_index.scss
@@ -59,3 +59,9 @@
 // * typography properties in CSS.
 // @see typography
 @forward "typography";
+
+// * forwarding the "children" module.
+// * The "children" module likely provides utilities for handling
+// * children HTML elements using CSS.
+// @see children
+@forward "children";

--- a/src/mixins/children/_after-first.scss
+++ b/src/mixins/children/_after-first.scss
@@ -1,0 +1,70 @@
+@charset "UTF-8";
+
+// @description
+// * after-first mixin.
+// * This mixin provides a convenient way to select the after-first child
+// * of element(s) in the current context.
+// * When you pass a number to the after-first mixin, it will select
+// * the after-first child element(s).
+
+// @access public
+
+// @version 1.0.0
+
+// @author Lucas Bonomi
+// @link: https://github.com/LukyVj/family.scss
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace children
+
+// @module children/after-first
+
+// @dependencies:
+// * - meta.type-of (SASS function).
+// * - LibFunc.cut-unit (function).
+// * - Error.throw (function).
+
+// @update
+// * We updated the mixin with validations
+
+// @param {Number} $num
+// * The number of children you want to select from.
+
+// @throw {Exception}
+// * Throws exceptions if the provided after-first parameter is not a number.
+
+// @example
+// * .example {
+// *   .child {
+// *     @include after-first(4) {
+// *        background-color: #212121;
+// *        color: #ffffff;
+// *     };
+// *   }
+// * }
+
+// @output
+// * .example .child:nth-child(n+4) {
+// *   background-color: #212121;
+// *   color: #ffffff;
+// * }
+
+@use "sass:meta";
+@use "sass:math";
+@use "../../functions/global/cut-unit" as LibFunc;
+@use "../../development-utils/toggle-error-message" as Error;
+
+@mixin after-first($num: 1) {
+    @if meta.type-of($num) != number {
+        content: Error.throw("The parameter of after-first mixin must be in a number type.");
+    }
+
+    $num-without-unit: LibFunc.cut-unit($num);
+
+    &:nth-child(n + #{$num-without-unit + 1}) {
+        @content;
+    }
+}

--- a/src/mixins/children/_all-but.scss
+++ b/src/mixins/children/_all-but.scss
@@ -1,0 +1,68 @@
+@charset "UTF-8";
+
+// @description
+// * all-but mixin.
+// * This mixin provides a convenient way to select the
+// * all children but one of elements in the current context.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Lucas Bonomi
+// @link: https://github.com/LukyVj/family.scss
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace children
+
+// @module children/all-but
+
+// @dependencies:
+// * - meta.type-of (SASS function).
+// * - LibFunc.cut-unit (function).
+// * - Error.throw (function).
+
+// @update
+// * We updated the mixin with validations.
+
+// @param {Number} $num
+// * The element you expect of range you want to select.
+
+// @throw {Exception}
+// * Throws exceptions if the provided all-but parameter is not a number.
+
+// @example
+// * .example {
+// *   .child {
+// *     @include all-but(4) {
+// *        background-color: #212121;
+// *        color: #ffffff;
+// *     };
+// *   }
+// * }
+
+// @output
+// * .example .child:not(:nth-child(4)) {
+// *   background-color: #212121;
+// *   color: #ffffff;
+// * }
+
+@use "sass:meta";
+@use "sass:math";
+@use "../../functions/global/cut-unit" as LibFunc;
+@use "../../development-utils/toggle-error-message" as Error;
+
+@mixin all-but($num) {
+    @if meta.type-of($num) != number {
+        content: Error.throw("The parameter of all-but mixin must be in a number type.");
+    }
+
+    $num-without-unit: LibFunc.cut-unit($num);
+
+    &:not(:nth-child(#{$num-without-unit})) {
+        @content;
+    }
+}

--- a/src/mixins/children/_between.scss
+++ b/src/mixins/children/_between.scss
@@ -26,11 +26,13 @@
 // * - Error.throw (function).
 
 // @update
-// * We updated the mixin with validations
+// * We updated the mixin with validations.
 
-// @param {Number} $num
-// * The number of children you want to select between them.
-// * The numbers you pass will be included in the range.
+// @param {Number} $first-num
+// * The first of range you want to select.
+
+// @param {Number} $last-num
+// * The last of range you want to select.
 
 // @throw {Exception}
 // * Throws exceptions if the provided between parameter is not a number.

--- a/src/mixins/children/_between.scss
+++ b/src/mixins/children/_between.scss
@@ -1,0 +1,70 @@
+@charset "UTF-8";
+
+// @description
+// * between mixin.
+// * This mixin provides a convenient way to select the
+// * between child of elements in the current context.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Lucas Bonomi
+// @link: https://github.com/LukyVj/family.scss
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace children
+
+// @module children/between
+
+// @dependencies:
+// * - meta.type-of (SASS function).
+// * - LibFunc.cut-unit (function).
+// * - Error.throw (function).
+
+// @update
+// * We updated the mixin with validations
+
+// @param {Number} $num
+// * The number of children you want to select between them.
+// * The numbers you pass will be included in the range.
+
+// @throw {Exception}
+// * Throws exceptions if the provided between parameter is not a number.
+
+// @example
+// * .example {
+// *   .child {
+// *     @include between(4, 10) {
+// *        background-color: #212121;
+// *        color: #ffffff;
+// *     };
+// *   }
+// * }
+
+// @output
+// * .example .child:nth-child(n+4):nth-child(-n+10) {
+// *   background-color: #212121;
+// *   color: #ffffff;
+// * }
+
+@use "sass:meta";
+@use "sass:math";
+@use "../../functions/global/cut-unit" as LibFunc;
+@use "../../development-utils/toggle-error-message" as Error;
+
+@mixin between($first-num: 1, $last-num) {
+    @if meta.type-of($first-num) != number or meta.type-of($last-num) != number {
+        content: Error.throw("The parameters of between mixin must be in a number type.");
+    }
+
+    $first-num-without-unit: LibFunc.cut-unit($first-num);
+    $last-num-without-unit: LibFunc.cut-unit($last-num);
+
+    &:nth-child(n + #{$first-num-without-unit}):nth-child(-n + #{$last-num-without-unit}) {
+        @content;
+    }
+}

--- a/src/mixins/children/_even-between.scss
+++ b/src/mixins/children/_even-between.scss
@@ -1,0 +1,72 @@
+@charset "UTF-8";
+
+// @description
+// * even-between mixin.
+// * This mixin provides a convenient way to select the
+// * even children between of elements in the current context.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Lucas Bonomi
+// @link: https://github.com/LukyVj/family.scss
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace children
+
+// @module children/even-between
+
+// @dependencies:
+// * - meta.type-of (SASS function).
+// * - LibFunc.cut-unit (function).
+// * - Error.throw (function).
+
+// @update
+// * We updated the mixin with validations
+
+// @param {Number} $first-num
+// * The first of range you want to select
+
+// @param {Number} $last-num
+// * The last of range you want to select
+
+// @throw {Exception}
+// * Throws exceptions if the provided even-between parameter is not a number.
+
+// @example
+// * .example {
+// *   .child {
+// *     @include even-between(4, 10) {
+// *        background-color: #212121;
+// *        color: #ffffff;
+// *     };
+// *   }
+// * }
+
+// @output
+// * .example .child:nth-child(even):nth-child(n+4):nth-child(-n+10) {
+// *   background-color: #212121;
+// *   color: #ffffff;
+// * }
+
+@use "sass:meta";
+@use "sass:math";
+@use "../../functions/global/cut-unit" as LibFunc;
+@use "../../development-utils/toggle-error-message" as Error;
+
+@mixin even-between($first-num: 1, $last-num) {
+    @if meta.type-of($first-num) != number or meta.type-of($last-num) != number {
+        content: Error.throw("The parameters of even-between mixin must be in a number type.");
+    }
+
+    $first-num-without-unit: LibFunc.cut-unit($first-num);
+    $last-num-without-unit: LibFunc.cut-unit($last-num);
+
+    &:nth-child(even):nth-child(n + #{$first-num-without-unit}):nth-child(-n + #{$last-num-without-unit}) {
+        @content;
+    }
+}

--- a/src/mixins/children/_first.scss
+++ b/src/mixins/children/_first.scss
@@ -1,0 +1,74 @@
+@charset "UTF-8";
+
+// @description
+// * first mixin.
+// * This mixin provides a convenient way to select the first child
+// * of element(s) in the current context.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Lucas Bonomi
+// @link: https://github.com/LukyVj/family.scss
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace children
+
+// @module children/first
+
+// @dependencies:
+// * - meta.type-of (SASS function).
+// * - LibFunc.cut-unit (function).
+// * - Error.throw (function).
+
+// @update
+// * We updated the mixin with validations
+
+// @param {Number} $num
+// * The number of children you want to select.
+
+// @throw {Exception}
+// * Throws exceptions if the provided first parameter is not a number.
+
+// @example
+// * .example {
+// *   .child {
+// *     @include first(10) {
+// *        background-color: #212121;
+// *        color: #ffffff;
+// *     };
+// *   }
+// * }
+
+// @output
+// * .example .child:nth-child(-n+10) {
+// *   background-color: #212121;
+// *   color: #ffffff;
+// * }
+
+@use "sass:meta";
+@use "sass:math";
+@use "../../functions/global/cut-unit" as LibFunc;
+@use "../../development-utils/toggle-error-message" as Error;
+
+@mixin first($num: 1) {
+    @if meta.type-of($num) != number {
+        content: Error.throw("The parameter of first mixin must be in a number type.");
+    }
+
+    $num-without-unit: LibFunc.cut-unit($num);
+
+    @if $num-without-unit == 1 {
+        &:first-child {
+            @content;
+        }
+    } @else {
+        &:nth-child(-n + #{$num-without-unit}) {
+            @content;
+        }
+    }
+}

--- a/src/mixins/children/_from-end.scss
+++ b/src/mixins/children/_from-end.scss
@@ -1,0 +1,70 @@
+@charset "UTF-8";
+
+// @description
+// * from-end mixin.
+// * This mixin provides a convenient way to select the
+// * from-end child of element in the current context.
+// * When you pass a number to the from-end mixin, it will select
+// * the child when we count from the end.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Lucas Bonomi
+// @link: https://github.com/LukyVj/family.scss
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace children
+
+// @module children/from-end
+
+// @dependencies:
+// * - meta.type-of (SASS function).
+// * - LibFunc.cut-unit (function).
+// * - Error.throw (function).
+
+// @update
+// * We updated the mixin with validations
+
+// @param {Number} $num
+// * The number of children you want to select from.
+
+// @throw {Exception}
+// * Throws exceptions if the provided from-end parameter is not a number.
+
+// @example
+// * .example {
+// *   .child {
+// *     @include from-end(4) {
+// *        background-color: #212121;
+// *        color: #ffffff;
+// *     };
+// *   }
+// * }
+
+// @output
+// * .example .child:nth-child(n+4) {
+// *   background-color: #212121;
+// *   color: #ffffff;
+// * }
+
+@use "sass:meta";
+@use "sass:math";
+@use "../../functions/global/cut-unit" as LibFunc;
+@use "../../development-utils/toggle-error-message" as Error;
+
+@mixin from-end($num: 1) {
+    @if meta.type-of($num) != number {
+        content: Error.throw("The parameter of from-end mixin must be in a number type.");
+    }
+
+    $num-without-unit: LibFunc.cut-unit($num);
+
+    &:nth-last-child(#{$num-without-unit}) {
+        @content;
+    }
+}

--- a/src/mixins/children/_index.scss
+++ b/src/mixins/children/_index.scss
@@ -53,3 +53,9 @@
 // * the odd-between child element(s).
 // @see odd-between
 @forward "odd-between";
+
+// * forwarding the "all-but" module.
+// * The "all-but" module probably contains mixin for selecting
+// * the all-but child element(s).
+// @see all-but
+@forward "all-but";

--- a/src/mixins/children/_index.scss
+++ b/src/mixins/children/_index.scss
@@ -47,3 +47,9 @@
 // * the even-between child element(s).
 // @see even-between
 @forward "even-between";
+
+// * forwarding the "odd-between" module.
+// * The "odd-between" module probably contains mixin for selecting
+// * the odd-between child element(s).
+// @see odd-between
+@forward "odd-between";

--- a/src/mixins/children/_index.scss
+++ b/src/mixins/children/_index.scss
@@ -35,3 +35,9 @@
 // * the from-end child element(s).
 // @see from-end
 @forward "from-end";
+
+// * forwarding the "between" module.
+// * The "between" module probably contains mixin for selecting
+// * the between child element(s).
+// @see between
+@forward "between";

--- a/src/mixins/children/_index.scss
+++ b/src/mixins/children/_index.scss
@@ -1,0 +1,19 @@
+@charset "UTF-8";
+
+// @description
+// * This file forwards various mixins for pseudo elements
+// * that will be useful to children elements.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins/flex-props
+
+// * forwarding the "first" module.
+// * The "first" module probably contains mixin for selecting
+// * the first child element(s).
+// @see first
+@forward "first";

--- a/src/mixins/children/_index.scss
+++ b/src/mixins/children/_index.scss
@@ -10,10 +10,16 @@
 
 // @repository: https://github.com/Black-Axis/sass-pire
 
-// @namespace mixins/flex-props
+// @namespace mixins/children
 
 // * forwarding the "first" module.
 // * The "first" module probably contains mixin for selecting
 // * the first child element(s).
 // @see first
 @forward "first";
+
+// * forwarding the "last" module.
+// * The "last" module probably contains mixin for selecting
+// * the last child element(s).
+// @see last
+@forward "last";

--- a/src/mixins/children/_index.scss
+++ b/src/mixins/children/_index.scss
@@ -23,3 +23,9 @@
 // * the last child element(s).
 // @see last
 @forward "last";
+
+// * forwarding the "after-first" module.
+// * The "after-first" module probably contains mixin for selecting
+// * the after-first child element(s).
+// @see after-first
+@forward "after-first";

--- a/src/mixins/children/_index.scss
+++ b/src/mixins/children/_index.scss
@@ -29,3 +29,9 @@
 // * the after-first child element(s).
 // @see after-first
 @forward "after-first";
+
+// * forwarding the "from-end" module.
+// * The "from-end" module probably contains mixin for selecting
+// * the from-end child element(s).
+// @see from-end
+@forward "from-end";

--- a/src/mixins/children/_index.scss
+++ b/src/mixins/children/_index.scss
@@ -41,3 +41,9 @@
 // * the between child element(s).
 // @see between
 @forward "between";
+
+// * forwarding the "even-between" module.
+// * The "even-between" module probably contains mixin for selecting
+// * the even-between child element(s).
+// @see even-between
+@forward "even-between";

--- a/src/mixins/children/_last.scss
+++ b/src/mixins/children/_last.scss
@@ -1,0 +1,74 @@
+@charset "UTF-8";
+
+// @description
+// * last mixin.
+// * This mixin provides a convenient way to select the last child
+// * of element(s) in the current context.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Lucas Bonomi
+// @link: https://github.com/LukyVj/family.scss
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace children
+
+// @module children/last
+
+// @dependencies:
+// * - meta.type-of (SASS function).
+// * - LibFunc.cut-unit (function).
+// * - Error.throw (function).
+
+// @update
+// * We updated the mixin with validations
+
+// @param {Number} $num
+// * The number of children you want to select.
+
+// @throw {Exception}
+// * Throws exceptions if the provided last parameter is not a number.
+
+// @example
+// * .example {
+// *   .child {
+// *     @include last(10) {
+// *        background-color: #212121;
+// *        color: #ffffff;
+// *     };
+// *   }
+// * }
+
+// @output
+// * .example .child:nth-child(-n+10) {
+// *   background-color: #212121;
+// *   color: #ffffff;
+// * }
+
+@use "sass:meta";
+@use "sass:math";
+@use "../../functions/global/cut-unit" as LibFunc;
+@use "../../development-utils/toggle-error-message" as Error;
+
+@mixin last($num: 1) {
+    @if meta.type-of($num) != number {
+        content: Error.throw("The parameter of last mixin must be in a number type.");
+    }
+
+    $num-without-unit: LibFunc.cut-unit($num);
+
+    @if $num-without-unit == 1 {
+        &:last-child {
+            @content;
+        }
+    } @else {
+        &:nth-last-child(-n + #{$num-without-unit}) {
+            @content;
+        }
+    }
+}

--- a/src/mixins/children/_odd-between.scss
+++ b/src/mixins/children/_odd-between.scss
@@ -1,0 +1,72 @@
+@charset "UTF-8";
+
+// @description
+// * odd-between mixin.
+// * This mixin provides a convenient way to select the
+// * odd children between of elements in the current context.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Lucas Bonomi
+// @link: https://github.com/LukyVj/family.scss
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace children
+
+// @module children/odd-between
+
+// @dependencies:
+// * - meta.type-of (SASS function).
+// * - LibFunc.cut-unit (function).
+// * - Error.throw (function).
+
+// @update
+// * We updated the mixin with validations
+
+// @param {Number} $first-num
+// * The first of range you want to select
+
+// @param {Number} $last-num
+// * The last of range you want to select
+
+// @throw {Exception}
+// * Throws exceptions if the provided odd-between parameter is not a number.
+
+// @example
+// * .example {
+// *   .child {
+// *     @include odd-between(4, 10) {
+// *        background-color: #212121;
+// *        color: #ffffff;
+// *     };
+// *   }
+// * }
+
+// @output
+// * .example .child:nth-child(odd):nth-child(n+4):nth-child(-n+10) {
+// *   background-color: #212121;
+// *   color: #ffffff;
+// * }
+
+@use "sass:meta";
+@use "sass:math";
+@use "../../functions/global/cut-unit" as LibFunc;
+@use "../../development-utils/toggle-error-message" as Error;
+
+@mixin odd-between($first-num: 1, $last-num) {
+    @if meta.type-of($first-num) != number or meta.type-of($last-num) != number {
+        content: Error.throw("The parameters of odd-between mixin must be in a number type.");
+    }
+
+    $first-num-without-unit: LibFunc.cut-unit($first-num);
+    $last-num-without-unit: LibFunc.cut-unit($last-num);
+
+    &:nth-child(odd):nth-child(n + #{$first-num-without-unit}):nth-child(-n + #{$last-num-without-unit}) {
+        @content;
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
None

## What does this pull request do?
<!-- Write your answer here-->
Add some mixins to select specific children form a range we want.

- Add `first` mixin.
- Add `last` mixin.
- Add `after-first` mixin.
- Add `from-end` mixin.
- Add `between` mixin.
- Add `even-between` mixin.
- Add `odd-between` mixin.
- Add `all-but` mixin.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
