### PR TITLE
fix(mixins-media-queries): :bug: fix `map_get` to be `map.get` function

### DIFF
--- a/src/mixins/media-queries/screens/_media-query.scss
+++ b/src/mixins/media-queries/screens/_media-query.scss
@@ -72,7 +72,7 @@
     @if LibFunc.is-in-list($main-mq-types, $type) {
         @if LibFunc.is-in-list($main-dimensions, $dimension) {
             @if map.has-key(var.$breakpoints, $breakpoint-name) {
-                $actual-dimension: map_get(var.$breakpoints, $breakpoint-name);
+                $actual-dimension: map.get(var.$breakpoints, $breakpoint-name);
     
                 @if $type == max {
                     $actual-dimension: $actual-dimension - 1px;


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
None

## What does this pull request do?
<!-- Write your answer here-->
- This `PR` fixes the issue of using the `map.get()` function in `sass` namespace.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
