### PR TITLE
Add `first-last` mixin to select `first` & `last` children.

### DIFF
--- a/src/mixins/children/_first-and-last.scss
+++ b/src/mixins/children/_first-and-last.scss
@@ -1,0 +1,45 @@
+@charset "UTF-8";
+
+// @description
+// * first-last mixin.
+// * This mixin provides a convenient way to select the first and last
+// * child in the current context.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Lucas Bonomi
+// @link: https://github.com/LukyVj/family.scss
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace children
+
+// @module children/first-last
+
+// @example
+// * .example {
+// *   .child {
+// *     @include first-last {
+// *        background-color: #212121;
+// *        color: #ffffff;
+// *     };
+// *   }
+// * }
+
+// @output
+// * .example .child:first-child,
+// * .example .child:last-child {
+// *   background-color: #212121;
+// *   color: #ffffff;
+// * }
+
+@mixin first-last() {
+    &:first-child,
+    &:last-child {
+        @content;
+    }
+}

--- a/src/mixins/children/_index.scss
+++ b/src/mixins/children/_index.scss
@@ -59,3 +59,9 @@
 // * the all-but child element(s).
 // @see all-but
 @forward "all-but";
+
+// * forwarding the "first-last" module.
+// * The "first-last" module probably contains mixin for selecting
+// * the first and last children.
+// @see first-last
+@forward "first-and-last";


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `first-last` mixin to select only the first and last children of an element.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
