### PR TITLE
Add `odd` mixin to select only odd children of an element

### DIFF
--- a/src/mixins/children/_index.scss
+++ b/src/mixins/children/_index.scss
@@ -60,8 +60,14 @@
 // @see all-but
 @forward "all-but";
 
-// * forwarding the "first-last" module.
-// * The "first-last" module probably contains mixin for selecting
+// * forwarding the "first-and-last" module.
+// * The "first-and-last" module probably contains mixin for selecting
 // * the first and last children.
-// @see first-last
+// @see first-and-last
 @forward "first-and-last";
+
+// * forwarding the "odd" module.
+// * The "odd" module probably contains mixin for selecting
+// * the first and last children.
+// @see odd
+@forward "odd";

--- a/src/mixins/children/_odd.scss
+++ b/src/mixins/children/_odd.scss
@@ -1,0 +1,43 @@
+@charset "UTF-8";
+
+// @description
+// * odd mixin.
+// * This mixin provides a convenient way to select the
+// * odd children between of elements in the current context.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Lucas Bonomi
+// @link: https://github.com/LukyVj/family.scss
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace children
+
+// @module children/odd
+
+// @example
+// * .example {
+// *   .child {
+// *     @include odd {
+// *        background-color: #212121;
+// *        color: #ffffff;
+// *     };
+// *   }
+// * }
+
+// @output
+// * .example .child:nth-child(odd) {
+// *   background-color: #212121;
+// *   color: #ffffff;
+// * }
+
+@mixin odd() {
+    &:nth-child(odd) {
+        @content;
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `odd` mixin to select all odd children of an element.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
