### PR TITLE
feat(utils): :sparkles: add `font-size` as utility classes

### DIFF
--- a/src/utils/typography/_font-size.scss
+++ b/src/utils/typography/_font-size.scss
@@ -1,0 +1,49 @@
+@charset "UTF-8";
+
+// @description
+// * font-size utility class.
+// * This file provides the `font-size` utility class.
+// * It can be used as a standalone class in any where it is needed.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace utils
+
+// @module utils/font-size
+
+// @dependencies:
+// * Nothing.
+
+// @example
+// * <div class="u-small"></div>
+
+// @output
+// * .u-small {
+// *   font-size: small;
+// * }
+
+$font-size-values: (
+    xx-small: xx-small,
+    x-small: x-small,
+    small: small,
+    smaller: smaller,
+    medium: medium,
+    large: large,
+    larger: larger,
+    x-large: x-large,
+    xx-large: xx-large,
+);
+
+@each $font-size-class-name, $font-size-value in $font-size-values {
+    .u-#{$font-size-class-name} {
+        font-size: $font-size-value;
+    }
+}

--- a/src/utils/typography/_index.scss
+++ b/src/utils/typography/_index.scss
@@ -46,3 +46,8 @@
 // * This module likely contains display white-space as class.
 // @see white-space
 @forward "white-space";
+
+// * forwarding the "font-size" module.
+// * This module likely contains display font-size as class.
+// @see font-size
+@forward "font-size";


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `font-size` as utility classes to be used in `HTML` easily.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
