### PR TITLE
fix(mixins-flex-props-main): :bug: replace `map-get` with `map.get`

### DIFF
--- a/src/mixins/flex-props/main-props/_flex-wrap.scss
+++ b/src/mixins/flex-props/main-props/_flex-wrap.scss
@@ -82,7 +82,7 @@
 
     @if LibFunc.is-in-list(map.keys($flex-wrap-map), $value) {
         // stylelint-disable-next-line scss/no-global-function-names
-        $flex-wrap-value: map-get($flex-wrap-map, $value);
+        $flex-wrap-value: map.get($flex-wrap-map, $value);
 
         @include LibMixin.prefixing-ms(flex-wrap, $flex-wrap-value);
     } @else {


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
None

## What does this pull request do?
<!-- Write your answer here-->
- Fix the using of `map` function and replace it with `map.get`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
