### PR TITLE
Update tests `map-get` deprecated with `map.get`

### DIFF
--- a/tests/mixins/flex-props/main-props/_align-items.test.scss
+++ b/tests/mixins/flex-props/main-props/_align-items.test.scss
@@ -36,13 +36,13 @@ $test-cases-align-items-map: (
         @include it("should output correct align-items properties") {
             @include assert {
                 @include output {
-                    #{map-get($case-data, selector)} {
+                    #{map.get($case-data, selector)} {
                         @include LibMixin.align-items(#{map.get($case-data, value)});
                     }
                 }
 
                 @include expect {
-                    #{map-get($case-data, selector)} {
+                    #{map.get($case-data, selector)} {
                         @each $property, $value in map.get($case-data, expected) {
                             #{$property}: #{$value};
                         }

--- a/tests/mixins/flex-props/main-props/_flex.test.scss
+++ b/tests/mixins/flex-props/main-props/_flex.test.scss
@@ -34,13 +34,13 @@ $test-cases-d-flex-map: (
         @include it("should output correct display flex properties") {
             @include assert {
                 @include output {
-                    #{map-get($case-data, selector)} {
+                    #{map.get($case-data, selector)} {
                         @include LibMixin.d-flex;
                     }
                 }
 
                 @include expect {
-                    #{map-get($case-data, selector)} {
+                    #{map.get($case-data, selector)} {
                         @each $value in map.get($case-data, expected) {
                             display: $value;
                         }


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
None

## What does this pull request do?
<!-- Write your answer here-->
- Fix the deprecated function in `map` module and converted from `map-get` to `map.get`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
