### PR TITLE
fix(functions-global): :bug: update using of `unitless` function to `math.is-unitless`

### DIFF
--- a/src/functions/global/_cut-unit.scss
+++ b/src/functions/global/_cut-unit.scss
@@ -55,11 +55,11 @@
     }
 
     // stylelint-disable-next-line length-zero-no-unit
-    @if math.unit($num) == "" and not unitless($num) {
+    @if math.unit($num) == "" and not math.is-unitless($num) {
         @return Error.throw("The parameter does not need a unit if it equals to zero.");
     }
 
-    @if meta.type-of($num) == number and not unitless($num) {
+    @if meta.type-of($num) == number and not math.is-unitless($num) {
         @return math.div($num, ($num * 0 + 1));
     }
 


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
None

## What does this pull request do?
<!-- Write your answer here-->
- As `sass-lang` said: Global built-in functions are deprecated and will be removed in Dart Sass `3.0.0`. Use math.is-unitless instead. So, we removed the global function in `unitless` and use the new version of it.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
