### PR TITLE
fix(functions-global): :bug: update using of `unitless` func to `is-unitless`

### DIFF
--- a/src/functions/global/_get-half-number.scss
+++ b/src/functions/global/_get-half-number.scss
@@ -21,7 +21,7 @@
 // @dependencies:
 // * - meta.type-of (SASS function).
 // * - math.unit (SASS function).
-// * - math.unitless (SASS function).
+// * - math.is-unitless (SASS function).
 // * - string.unquote (SASS function).
 // * - LibFunc.cut-unit (function).
 // * - Error.throw (function).
@@ -65,7 +65,7 @@
         @return 0;
     }
 
-    @if not unitless($number) {
+    @if not math.is-unitless($number) {
         $num-after-cut-unit: LibFunc.cut-unit($number);
         $unit-of-number: math.unit($number);
 


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
None

## What does this pull request do?
<!-- Write your answer here-->
- As `sass-lang` said: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0. Use math.is-unitless instead. So, we removed the global function in `unitless` and use the new version of it.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Paste screenshot here -->
None
