### PR TITLE
fix(development-utils): :bug: fix using of `unitless` function with `math.is-unitless`

### DIFF
--- a/src/development-utils/_approximation-numbers.scss
+++ b/src/development-utils/_approximation-numbers.scss
@@ -24,6 +24,7 @@
 // * - meta.type-of (SASS function).
 // * - math.div (SASS function).
 // * - math.round (SASS function).
+// * - math.math.is-unitless (SASS function).
 // * - math.ceil (SASS function).
 // * - math.floor (SASS function).
 // * - LibFunc.cut-unit (function).
@@ -86,7 +87,7 @@
         @return Error.throw("The mode parameter of approx function must be in a string type.");
     }
 
-    @if not unitless($num) {
+    @if not math.is-unitless($num) {
         $num-unit: math.unit($num);
     }
 


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Replace using of `unitless` function with `math.is-unitless`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
