### PR TITLE
fix(mixins-general): :bug: fix using of `unitless` function with `math.is-unitless`

### DIFF
--- a/src/mixins/general/_square.scss
+++ b/src/mixins/general/_square.scss
@@ -20,6 +20,7 @@
 
 // @dependencies:
 // * - meta.type-of (SASS function).
+// * - math.is-unitless (SASS function).
 // * - math.unit (SASS function).
 // * - var.$all-units (variable).
 // * - LibFunc.is-in-list (function).
@@ -55,7 +56,7 @@
 
 @mixin square($one-side: 1px) {
     @if meta.type-of($one-side) == number {
-        @if not unitless($one-side) {
+        @if not math.is-unitless($one-side) {
             @if LibFunc.is-in-list(var.$all-units, math.unit($one-side)) {
                 --sp-one-side: #{$one-side};
 


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Replace using of `unitless` function with `math.is-unitless`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
