### PR TITLE
fix using of `unitless` function with `math.is-unitless`

### DIFF
--- a/src/mixins/grid-props/_column-gap.scss
+++ b/src/mixins/grid-props/_column-gap.scss
@@ -24,6 +24,7 @@
 
 // @dependencies:
 // * - meta.type-of (SASS function).
+// * - math.is-unitless (SASS function).
 // * - LibFunc.is-in-list (function).
 // * - Error.throw (function).
 
@@ -64,7 +65,7 @@
             );
         }
     } @else if meta.type-of($value) == number {
-        @if not unitless($value) {
+        @if not math.is-unitless($value) {
             @each $one-item in $column-gap-prefixes-values {
                 #{$one-item}: #{$value};
             }


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Replace using of `unitless` function with `math.is-unitless`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
