### PR TITLE
feat(media-queries-prefers): :sparkles: add `dark-mode` mixin to handle `prefers-color-scheme` in dark

### DIFF
--- a/src/mixins/media-queries/prefers/_dark-mode.scss
+++ b/src/mixins/media-queries/prefers/_dark-mode.scss
@@ -1,0 +1,44 @@
+@charset "UTF-8";
+
+// @description
+// * dark-mode mixin.
+// * Generate a media query for prefers-color-scheme with dark mode.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @reference: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
+
+// @namespace general
+
+// @module prefers/dark-mode
+
+// @dependencies:
+// * - None.
+
+// @example
+// * .example {
+// *   @include dark-mode {
+// *     width: 100px;
+// *   }
+// * }
+
+// @output
+// * @media (prefers-color-scheme: dark) {
+// *   .example {
+// *     width: 100px;
+// *   }
+// * }
+
+@mixin dark-mode() {
+    @media (prefers-color-scheme: dark) {
+        @content;
+    }
+}

--- a/src/mixins/media-queries/prefers/_index.scss
+++ b/src/mixins/media-queries/prefers/_index.scss
@@ -13,6 +13,12 @@
 
 // * forwarding the "light-mode" module.
 // * The "light-mode" module likely contains styles for
-// * responsive designs.
+// * prefers color scheme in light mode.
 // @see light-mode
 @forward "light-mode";
+
+// * forwarding the "dark-mode" module.
+// * The "dark-mode" module likely contains styles for
+// * prefers color scheme in dark mode.
+// @see dark-mode
+@forward "dark-mode";


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `dark-mode` to handle `prefers-color-scheme` for `dark` mode.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
