### PR TITLE
test(tests): :white_check_mark: add `test cases` for `flex-direction` mixin

### DIFF
--- a/tests/mixins/flex-props/main-props/_flex-direction.test.scss
+++ b/tests/mixins/flex-props/main-props/_flex-direction.test.scss
@@ -1,0 +1,84 @@
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/flex-props/main-props/flex-direction" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+
+$test-cases-flex-direction-map: (
+    "test-case-1": (
+        selector: ".test-flex-direction-column",
+        value: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column
+        )
+    ),
+    "test-case-2": (
+        selector: ".test-flex-direction-column-reverse",
+        value: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse
+        ),
+    ),
+    "test-case-3": (
+        selector: ".test-flex-direction-row",
+        value: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row
+        ),
+    ),
+    "test-case-4": (
+        selector: ".test-flex-direction-row-reverse",
+        value: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-direction-map {
+    @include describe("[Mixin] flex-direction for #{$case-name}") {
+        @include it("should output correct flex-direction properties") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-dir(#{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/main-props/_index.scss
+++ b/tests/mixins/flex-props/main-props/_index.scss
@@ -34,3 +34,9 @@
 // * align self with its vendor prefixes.
 // @see align-self
 @forward "align-self.test";
+
+// * forwarding the "flex-direction" module.
+// * The "flex-direction" module likely provides a test cases for
+// * flex-direction with its vendor prefixes.
+// @see flex-direction
+@forward "flex-direction.test";


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `test cases` for the `flex-dir` mixin which implements the `flex-direction` CSS property.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
