### PR TITLE
refactor(tests): :recycle: add `comma` in last child in `expected` prop in map

### DIFF
--- a/tests/mixins/flex-props/main-props/_align-self.test.scss
+++ b/tests/mixins/flex-props/main-props/_align-self.test.scss
@@ -16,7 +16,7 @@ $test-cases-align-self-map: (
             -ms-align-self: start,
             -moz-align-self: start,
             -o-align-self: start,
-            align-self: start
+            align-self: start,
         )
     ),
     "test-case-2": (
@@ -28,7 +28,7 @@ $test-cases-align-self-map: (
             -ms-align-self: center,
             -moz-align-self: center,
             -o-align-self: center,
-            align-self: center
+            align-self: center,
         ),
     ),
 );

--- a/tests/mixins/flex-props/main-props/_flex-direction.test.scss
+++ b/tests/mixins/flex-props/main-props/_flex-direction.test.scss
@@ -17,7 +17,7 @@ $test-cases-flex-direction-map: (
             -ms-flex-direction: column,
             -moz-flex-direction: column,
             -o-flex-direction: column,
-            flex-direction: column
+            flex-direction: column,
         )
     ),
     "test-case-2": (
@@ -30,7 +30,7 @@ $test-cases-flex-direction-map: (
             -ms-flex-direction: column-reverse,
             -moz-flex-direction: column-reverse,
             -o-flex-direction: column-reverse,
-            flex-direction: column-reverse
+            flex-direction: column-reverse,
         ),
     ),
     "test-case-3": (
@@ -43,7 +43,7 @@ $test-cases-flex-direction-map: (
             -ms-flex-direction: row,
             -moz-flex-direction: row,
             -o-flex-direction: row,
-            flex-direction: row
+            flex-direction: row,
         ),
     ),
     "test-case-4": (
@@ -56,7 +56,7 @@ $test-cases-flex-direction-map: (
             -ms-flex-direction: row-reverse,
             -moz-flex-direction: row-reverse,
             -o-flex-direction: row-reverse,
-            flex-direction: row-reverse
+            flex-direction: row-reverse,
         ),
     ),
 );

--- a/tests/mixins/flex-props/main-props/_flex.test.scss
+++ b/tests/mixins/flex-props/main-props/_flex.test.scss
@@ -14,7 +14,7 @@ $test-cases-d-flex-map: (
             -moz-box,
             -ms-flexbox,
             -webkit-flex,
-            flex
+            flex,
         )
     ),
     "test-case-2": (
@@ -24,7 +24,7 @@ $test-cases-d-flex-map: (
             -moz-box,
             -ms-flexbox,
             -webkit-flex,
-            flex
+            flex,
         )
     ),
 );


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `comma` in last child in `expected` prop in map.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
