### PR TITLE
refactor(mixins-flex-props-main): :recycle: move `$flex-shrink-values` in `global-vars` & enhance `f-s` mixin

### DIFF
--- a/src/abstract/_global-variables.scss
+++ b/src/abstract/_global-variables.scss
@@ -204,6 +204,14 @@ $align-items-values: (
     inherit
 ) !default;
 
+$flex-shrink-values: (
+    initial,
+    revert,
+    revert-layer,
+    unset,
+    inherit,
+) !default;
+
 $column-gap-props: (
     -webkit-column-gap,
     -moz-column-gap,

--- a/src/mixins/flex-props/main-props/_flex-shrink.scss
+++ b/src/mixins/flex-props/main-props/_flex-shrink.scss
@@ -62,6 +62,7 @@
 
 @use "sass:meta";
 @use "../../../functions/global" as LibFunc;
+@use "../../../abstract/global-variables" as var;
 @use "../../../development-utils/toggle-error-message" as Error;
 
 @mixin flex-shrink($value) {
@@ -74,18 +75,18 @@
         flex-shrink
     ) !default;
 
-    $flex-shrink-values: (initial, inherit) !default;
-
     @if meta.type-of($value) == string {
-        @if LibFunc.is-in-list($flex-shrink-values, $value) {
+        @if LibFunc.is-in-list(var.$flex-shrink-values, $value) {
             @each $prop in $flex-shrink-props {
                 // stylelint-disable-next-line scss/no-global-function-names
                 #{$prop}: if(meta.type-of($value) == string, $value, LibFunc.cut-unit($value));
             }
         } @else {
-            content: Error.throw("The parameter of flex-shrink mixin must be one of: (#{$flex-shrink-values}).");
+            content: Error.throw("The parameter of flex-shrink mixin must be one of: (#{var.$flex-shrink-values}).");
         }
-    } @else if meta.type-of($value) == number {
+    }
+
+    @if meta.type-of($value) == number {
         @if $value < 0 {
             content: Error.throw("The parameter of flex-shrink mixin must be greater than or equal to zero.");
         } @else {
@@ -94,8 +95,6 @@
                 #{$prop}: if(meta.type-of($value) == string, $value, LibFunc.cut-unit($value));
             }
         }
-    } @else {
-        content: Error.throw("The parameter of flex-shrink mixin must be in type string or a number.");
     }
 }
 


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Move the local variable `$flex-shrink-values` in `_global-variables.scss` file to be shared in the `flex-shrink` mixin and its `unit test cases`.
- Update and enhance some of core logic of `flex-shrink` mixin.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
