### PR TITLE
feat(config-file): :sparkles: add comment to show we use `reset-zone` package in `sass-pire`

### DIFF
--- a/build/constants.js
+++ b/build/constants.js
@@ -52,6 +52,8 @@ const getBannerText = () => {
             ***** #{Settings.$author-names}.
 
             ***** Licensed under MIT.
+
+            ***** To make a reset for CSS, We used the reset-zone library.
         */
     }`;
 };


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add a new comment to `banner` to show that the `sass-pire` uses the `reset-zone` package for its reset CSS.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
