### PR TITLE
Replace `string` function & fix `bugs` in `flex-basis` mixin

### DIFF
--- a/src/mixins/flex-props/main-props/_flex-basis.scss
+++ b/src/mixins/flex-props/main-props/_flex-basis.scss
@@ -71,18 +71,14 @@
 @mixin flex-basis($value: auto) {
     $flex-basis-props: (
         -webkit-flex-basis,
-        -ms-flex-basis,
         -ms-flex-preferred-size,
-        -moz-flex-basis,
-        -moz-box-sizing,
-        -o-flex-basis,
         flex-basis
     ) !default;
 
     // stylelint-disable-next-line scss/dollar-variable-empty-line-before
     $flex-basis-values: (max-content, min-content, fit-content, content, inherit, auto) !default;
 
-    @if meta.type-of($value) == string or meta.type-of($value) == number {
+    @if meta.type-of($value) == string {
         @if meta.type-of($value) == string {
             @if LibFunc.is-in-list($flex-basis-values, $value) {
                 @each $prop in $flex-basis-props {
@@ -92,18 +88,16 @@
                 content: Error.throw("The parameter of flex-basis mixin must be one of: (#{$flex-basis-values}).");
             }
         }
+    }
 
-        @if meta.type-of($value) == number and LibFunc.cut-unit($value) != 0 {
-            @if math.unitless($value) {
-                @error "Please, Enter the unit of $value argument. It must be one of these units (#{$flex-basis-values})";
-            }
-
+    @if meta.type-of($value) == number {
+        @if $value < 0 {
+            content: Error.throw("The parameter of flex-basis mixin must be greater than or equal to zero.");
+        } @else {
             @each $prop in $flex-basis-props {
                 #{$prop}: $value;
             }
         }
-    } @else {
-        @error "#{$value} argument must has be of type number or string.";
     }
 }
 

--- a/tests/mixins/flex-props/main-props/_flex-shrink.test.scss
+++ b/tests/mixins/flex-props/main-props/_flex-shrink.test.scss
@@ -105,7 +105,7 @@ $test-cases-flex-shrink-map: (
 
                         @if meta.type-of($current-value) != number {
                             // stylelint-disable-next-line scss/no-global-function-names
-                            $first-char: str-slice(#{$current-value}, 1, 1);
+                            $first-char: string.slice(#{$current-value}, 1, 1);
 
                             // Check if it looks like a numeric string
                             @if $first-char == "0" or

--- a/tests/mixins/flex-props/main-props/_order.test.scss
+++ b/tests/mixins/flex-props/main-props/_order.test.scss
@@ -63,7 +63,7 @@ $test-cases-order-map: (
 
                         @if meta.type-of($current-value) != number {
                             // stylelint-disable-next-line scss/no-global-function-names
-                            $first-char: str-slice(#{$current-value}, 1, 1);
+                            $first-char: string.slice(#{$current-value}, 1, 1);
 
                             // Check if it looks like a numeric string
                             @if $first-char == "0" or


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Replace the `str-slice()` global function with `string.slice()` because it will be deprecated in the new version of `SCSS` in `_flex-shrink.test.scss` and `_order.test.scss`.
- Fix `bugs` in `flex-basis` mixin with the `number` and `string` parameter.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
