### PR TITLE
fix(mixins-flex-props-main): :ambulance: fix incorrect used paths in `inflex-prop` mixin

### DIFF
--- a/src/mixins/flex-props/main-props/_inflex-prop.scss
+++ b/src/mixins/flex-props/main-props/_inflex-prop.scss
@@ -68,10 +68,10 @@
 // *   align-items: center;
 // * }
 
-@use "inline-flex" as f;
-@use "flex-direction" as dir;
-@use "justify-content" as jc;
-@use "align-items" as ai;
+@use "./inline-flex" as f;
+@use "./flex-direction" as dir;
+@use "./justify-content" as jc;
+@use "./align-items" as ai;
 
 @mixin inflex-prop($f-dir: row, $justify-content-val: flex-start, $align-items-val: normal) {
     @include f.d-inflex;


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Fix critical `incorrect paths` of mixins which are used in `inflex-prop` mixin file.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
