### PR TITLE
chore(config-file): :wrench: refactor `ignoreFiles` key to ignore all `.css` & `.min.css` files

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,7 +1,10 @@
 {
     "plugins": ["stylelint-scss"],
     "extends": ["stylelint-config-standard", "stylelint-config-standard-scss"],
-    "ignoreFiles": ["dist/styles.css", "dist/test-styles.css", "dist/styles.min.css"],
+    "ignoreFiles": [
+        "dist/*.css",
+        "dist/*.min.css"
+    ],
     "rules": {
         "no-duplicate-selectors": true,
         "no-duplicate-at-import-rules": true,


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add all files in `dist` folder which end with `.css` and `.min.css` files to `ignoreFiles` key in `.stylelintrc` file.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
