### PR TITLE
refactor(tests): :recycle: update import of `true` package & update usage

### DIFF
--- a/tests/functions/global/_cut-unit.test.scss
+++ b/tests/functions/global/_cut-unit.test.scss
@@ -27,7 +27,7 @@
 // stylelint-disable number-max-precision
 // stylelint-disable function-name-case
 
-@use "../../../node_modules/sass-true/sass/true" as True;
+@use "true" as *;
 @use "../../../src/functions/global/cut-unit" as LibFunc;
 @use "../../../src/development-utils/error" as Dev;
 
@@ -47,9 +47,9 @@ $test-cases-cut-unit-map: (
 );
 
 @each $case, $result in $test-cases-cut-unit-map {
-    @include True.describe("[Function] cut-unit(#{$case}), Result: #{$result}") {
-        @include True.it("Cut the unit of (#{$case}) value.") {
-            @include True.assert-equal(LibFunc.cut-unit($case), $result);
+    @include describe("[Function] cut-unit(#{$case}), Result: #{$result}") {
+        @include it("Cut the unit of (#{$case}) value.") {
+            @include assert-equal(LibFunc.cut-unit($case), $result);
         }
     }
 }

--- a/tests/functions/global/_get-half-number.test.scss
+++ b/tests/functions/global/_get-half-number.test.scss
@@ -27,7 +27,7 @@
 // stylelint-disable number-max-precision
 // stylelint-disable function-name-case
 
-@use "../../../node_modules/sass-true/sass/true" as True;
+@use "true" as *;
 @use "../../../src/functions/global/get-half-number" as LibFunc;
 @use "../../../src/development-utils/error" as Dev;
 
@@ -47,9 +47,9 @@ $test-cases-half-map: (
 );
 
 @each $case, $result in $test-cases-half-map {
-    @include True.describe("[Function] half(#{$case}), Result: #{$result}") {
-        @include True.it("half of (#{$case}) value.") {
-            @include True.assert-equal(LibFunc.half($case), $result);
+    @include describe("[Function] half(#{$case}), Result: #{$result}") {
+        @include it("half of (#{$case}) value.") {
+            @include assert-equal(LibFunc.half($case), $result);
         }
     }
 }

--- a/tests/functions/global/_has-position.test.scss
+++ b/tests/functions/global/_has-position.test.scss
@@ -27,7 +27,7 @@
 // stylelint-disable number-max-precision
 // stylelint-disable function-name-case
 
-@use "../../../node_modules/sass-true/sass/true" as True;
+@use "true" as *;
 @use "../../../src/functions/global/has-position" as LibFunc;
 @use "../../../src/development-utils/error" as Dev;
 
@@ -51,9 +51,9 @@ $test-cases-has-position-map: (
 );
 
 @each $case, $result in $test-cases-has-position-map {
-    @include True.describe("[Function] has-pos(#{$case}), Result: #{$result}") {
-        @include True.it("has-pos(#{$case}) value.") {
-            @include True.assert-equal(LibFunc.has-pos($case), $result);
+    @include describe("[Function] has-pos(#{$case}), Result: #{$result}") {
+        @include it("has-pos(#{$case}) value.") {
+            @include assert-equal(LibFunc.has-pos($case), $result);
         }
     }
 }

--- a/tests/functions/global/_is-in-list.test.scss
+++ b/tests/functions/global/_is-in-list.test.scss
@@ -28,7 +28,7 @@
 // stylelint-disable function-name-case
 
 @use "sass:map";
-@use "../../../node_modules/sass-true/sass/true" as True;
+@use "true" as *;
 @use "../../../src/functions/global/is-in-list" as LibFunc;
 @use "../../../src/development-utils/error" as Dev;
 
@@ -75,9 +75,9 @@ $test-cases-is-in-list-map: (
     $given-value: map.get($inner, "given");
     $expected-value: map.get($inner, "expected");
 
-    @include True.describe("[Function] is-in-list(#{$list-value}, #{$given-value}), Result: #{$expected-value}") {
-        @include True.it("is-in-list(#{$list-value}, #{$given-value}) value.") {
-            @include True.assert-equal(LibFunc.is-in-list($list-value, $given-value), $expected-value);
+    @include describe("[Function] is-in-list(#{$list-value}, #{$given-value}), Result: #{$expected-value}") {
+        @include it("is-in-list(#{$list-value}, #{$given-value}) value.") {
+            @include assert-equal(LibFunc.is-in-list($list-value, $given-value), $expected-value);
         }
     }
 }

--- a/tests/functions/global/_sum.test.scss
+++ b/tests/functions/global/_sum.test.scss
@@ -27,7 +27,7 @@
 // stylelint-disable function-name-case
 
 @use "sass:map";
-@use "../../../node_modules/sass-true/sass/true" as True;
+@use "true" as *;
 @use "../../../src/functions/global/sum" as LibFunc;
 @use "../../../src/development-utils/error" as Dev;
 
@@ -47,9 +47,9 @@ $test-cases-sum-map: (
 );
 
 @each $case, $result in $test-cases-sum-map {
-    @include True.describe("[Function] sum(#{$case}), Result: #{$result}") {
-        @include True.it("sum(#{$case}) value.") {
-            @include True.assert-equal(LibFunc.sum($case), $result);
+    @include describe("[Function] sum(#{$case}), Result: #{$result}") {
+        @include it("sum(#{$case}) value.") {
+            @include assert-equal(LibFunc.sum($case), $result);
         }
     }
 }


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Update `import` statement of `sass-true` package in files at path: `tests/functions/global/_*.test.scss`.
- Update use of `sass-true` package by removing `True.` when using its `functions` or `mixins`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
