### PR TITLE
refactor(tests): :recycle: update import of `true` package & update usage

### DIFF
--- a/tests/functions/list/_flatten-list.test.scss
+++ b/tests/functions/list/_flatten-list.test.scss
@@ -27,7 +27,7 @@
 // stylelint-disable function-name-case
 
 @use "sass:map";
-@use "../../../node_modules/sass-true/sass/true" as True;
+@use "true" as *;
 @use "../../../src/functions/list/flatten-list" as LibFunc;
 @use "../../../src/development-utils/error" as Dev;
 
@@ -43,9 +43,9 @@ $test-cases-flatten-list-map: (
 );
 
 @each $case, $result in $test-cases-flatten-list-map {
-    @include True.describe("[Function] flatten(#{$case}), Result: #{$result}") {
-        @include True.it("Flatten of (#{$case}).") {
-            @include True.assert-equal(LibFunc.flatten($case), $result);
+    @include describe("[Function] flatten(#{$case}), Result: #{$result}") {
+        @include it("Flatten of (#{$case}).") {
+            @include assert-equal(LibFunc.flatten($case), $result);
         }
     }
 }

--- a/tests/functions/list/_get-centered-element-list.test.scss
+++ b/tests/functions/list/_get-centered-element-list.test.scss
@@ -27,7 +27,7 @@
 // stylelint-disable function-name-case
 
 @use "sass:map";
-@use "../../../node_modules/sass-true/sass/true" as True;
+@use "true" as *;
 @use "../../../src/functions/list/get-centered-element-list" as LibFunc;
 @use "../../../src/development-utils/error" as Dev;
 
@@ -42,9 +42,9 @@ $test-cases-center-of-list-map: (
 );
 
 @each $case, $result in $test-cases-center-of-list-map {
-    @include True.describe("[Function] center-of-list(#{$case}), Result: #{$result}") {
-        @include True.it("center-of-list(#{$case}).") {
-            @include True.assert-equal(LibFunc.center-of-list($case), $result);
+    @include describe("[Function] center-of-list(#{$case}), Result: #{$result}") {
+        @include it("center-of-list(#{$case}).") {
+            @include assert-equal(LibFunc.center-of-list($case), $result);
         }
     }
 }

--- a/tests/functions/list/_get-first-element.test.scss
+++ b/tests/functions/list/_get-first-element.test.scss
@@ -27,7 +27,7 @@
 // stylelint-disable function-name-case
 
 @use "sass:map";
-@use "../../../node_modules/sass-true/sass/true" as True;
+@use "true" as *;
 @use "../../../src/functions/list/get-first-element" as LibFunc;
 @use "../../../src/development-utils/error" as Dev;
 
@@ -42,9 +42,9 @@ $test-cases-get-first-from-map: (
 );
 
 @each $case, $result in $test-cases-get-first-from-map {
-    @include True.describe("[Function] get-first-from(#{$case}), Result: #{$result}") {
-        @include True.it("get-first-from(#{$case}).") {
-            @include True.assert-equal(LibFunc.get-first-from($case), $result);
+    @include describe("[Function] get-first-from(#{$case}), Result: #{$result}") {
+        @include it("get-first-from(#{$case}).") {
+            @include assert-equal(LibFunc.get-first-from($case), $result);
         }
     }
 }

--- a/tests/functions/list/_get-last-element.test.scss
+++ b/tests/functions/list/_get-last-element.test.scss
@@ -27,7 +27,7 @@
 // stylelint-disable function-name-case
 
 @use "sass:map";
-@use "../../../node_modules/sass-true/sass/true" as True;
+@use "true" as *;
 @use "../../../src/functions/list/get-last-element" as LibFunc;
 @use "../../../src/development-utils/error" as Dev;
 
@@ -42,9 +42,9 @@ $test-cases-get-last-from-map: (
 );
 
 @each $case, $result in $test-cases-get-last-from-map {
-    @include True.describe("[Function] get-last-from(#{$case}), Result: #{$result}") {
-        @include True.it("get-last-from(#{$case}).") {
-            @include True.assert-equal(LibFunc.get-last-from($case), $result);
+    @include describe("[Function] get-last-from(#{$case}), Result: #{$result}") {
+        @include it("get-last-from(#{$case}).") {
+            @include assert-equal(LibFunc.get-last-from($case), $result);
         }
     }
 }

--- a/tests/functions/list/_merge.test.scss
+++ b/tests/functions/list/_merge.test.scss
@@ -27,7 +27,7 @@
 // stylelint-disable function-name-case
 
 @use "sass:map";
-@use "../../../node_modules/sass-true/sass/true" as True;
+@use "true" as *;
 @use "../../../src/functions/list/merge" as LibFunc;
 @use "../../../src/development-utils/error" as Dev;
 
@@ -42,9 +42,9 @@ $test-cases-merge-map: (
 );
 
 @each $case, $result in $test-cases-merge-map {
-    @include True.describe("[Function] merge(#{$case}), Result: #{$result}") {
-        @include True.it("merge(#{$case}).") {
-            @include True.assert-equal(LibFunc.merge($case), $result);
+    @include describe("[Function] merge(#{$case}), Result: #{$result}") {
+        @include it("merge(#{$case}).") {
+            @include assert-equal(LibFunc.merge($case), $result);
         }
     }
 }

--- a/tests/functions/list/_reverse.test.scss
+++ b/tests/functions/list/_reverse.test.scss
@@ -27,7 +27,7 @@
 // stylelint-disable function-name-case
 
 @use "sass:map";
-@use "../../../node_modules/sass-true/sass/true" as True;
+@use "true" as *;
 @use "../../../src/functions/list/reverse" as LibFunc;
 @use "../../../src/development-utils/error" as Dev;
 
@@ -42,9 +42,9 @@ $test-cases-reverse-map: (
 );
 
 @each $case, $result in $test-cases-reverse-map {
-    @include True.describe("[Function] reverse(#{$case}), Result: #{$result}") {
-        @include True.it("reverse(#{$case}).") {
-            @include True.assert-equal(LibFunc.reverse($case), $result);
+    @include describe("[Function] reverse(#{$case}), Result: #{$result}") {
+        @include it("reverse(#{$case}).") {
+            @include assert-equal(LibFunc.reverse($case), $result);
         }
     }
 }


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Update `import` statement of `sass-true` package in files at path: `tests/functions/list/_*.test.scss`.
- Update use of `sass-true` package by removing `True.` when using its `functions` or `mixins`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
