### PR TITLE
add `unit tests` for `flex-between-start` & `flex-between-inherit` mixins

### DIFF
--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-inherit.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-inherit.test.scss
@@ -1,0 +1,131 @@
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-between-inherit-map: (
+    ".test-case-1": (
+        selector: ".test-flex-between-inherit-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-between-inherit-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-between-inherit-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-between-inherit-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-between-inherit-map {
+    @include describe("[Mixin] flex-between-inherit") {
+        @include it("should output correct flex-between-inherit values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-between-inh(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-start.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-start.test.scss
@@ -1,0 +1,131 @@
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-between-start-map: (
+    ".test-case-1": (
+        selector: ".test-flex-between-start-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-between-start-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-between-start-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-between-start-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-between-start-map {
+    @include describe("[Mixin] flex-between-start") {
+        @include it("should output correct flex-between-start values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-between-start(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_index.scss
@@ -46,3 +46,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flex-between-fstart.test
 @forward "./flex-between-fstart.test";
+
+// * forwarding the "flex-between-inherit.test" module.
+// * The "flex-between-inherit.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-between-inherit.test
+@forward "./flex-between-inherit.test";

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_index.scss
@@ -52,3 +52,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flex-between-inherit.test
 @forward "./flex-between-inherit.test";
+
+// * forwarding the "flex-between-start.test" module.
+// * The "flex-between-start.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-between-start.test
+@forward "./flex-between-start.test";


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `unit tests` for `flex-between-start` mixin to handle all cases.
- Add `unit tests` for `flex-between-inherit` mixin to handle all cases.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
