### PR TITLE
add `unit tests` for `flex-between-stretch` and `flex-center-baseline` mixins

### DIFF
--- a/tests/mixins/flex-props/flexbox/_index.scss
+++ b/tests/mixins/flex-props/flexbox/_index.scss
@@ -22,3 +22,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flexbox-between
 @forward "flexbox-between";
+
+// * forwarding the "flexbox-center" module.
+// * The "flexbox-center" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flexbox-center
+@forward "flexbox-center";

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-stretch.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-stretch.test.scss
@@ -1,0 +1,131 @@
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-between-stretch-map: (
+    ".test-case-1": (
+        selector: ".test-flex-between-stretch-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-between-stretch-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-between-stretch-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-between-stretch-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: space-between,
+            -webkit-justify-content: space-between,
+            -ms-flex-pack: space-between,
+            -moz-justify-content: space-between,
+            justify-content: space-between,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-between-stretch-map {
+    @include describe("[Mixin] flex-between-stretch") {
+        @include it("should output correct flex-between-stretch values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-between-stretch(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_index.scss
@@ -58,3 +58,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flex-between-start.test
 @forward "./flex-between-start.test";
+
+// * forwarding the "flex-between-stretch.test" module.
+// * The "flex-between-stretch.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-between-stretch.test
+@forward "./flex-between-stretch.test";

--- a/tests/mixins/flex-props/flexbox/flexbox-center/_flex-center-baseline.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-center/_flex-center-baseline.test.scss
@@ -1,0 +1,127 @@
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/center" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-center-baseline-map: (
+    ".test-case-1": (
+        selector: ".test-flex-center-baseline-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: center,
+            -webkit-justify-content: center,
+            -ms-flex-pack: center,
+            -moz-justify-content: center,
+            justify-content: center,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-center-baseline-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: center,
+            -webkit-justify-content: center,
+            -ms-flex-pack: center,
+            -moz-justify-content: center,
+            justify-content: center,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-center-baseline-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: center,
+            -webkit-justify-content: center,
+            -ms-flex-pack: center,
+            -moz-justify-content: center,
+            justify-content: center,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-center-baseline-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: center,
+            -webkit-justify-content: center,
+            -ms-flex-pack: center,
+            -moz-justify-content: center,
+            justify-content: center,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-center-baseline-map {
+    @include describe("[Mixin] flex-center-baseline") {
+        @include it("should output correct flex-center-baseline values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-center-baseline(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-center/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-center/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases for justify-content with value center.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "flex-center-baseline.test" module.
+// * The "flex-center-baseline.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-center-baseline.test
+@forward "./flex-center-baseline.test";


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `unit tests` for `flex-center-baseline` mixin to handle all test cases.
- Add `unit tests` for `flex-between-stretch` mixin to handle all test cases.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
