### PR TITLE
feat(mixins-flex-props-main): :sparkles: add `$flex-prefixes-values` as `global variable`

### DIFF
--- a/src/abstract/_global-variables.scss
+++ b/src/abstract/_global-variables.scss
@@ -162,6 +162,14 @@ $main-directions: (
     left,
 ) !default;
 
+$flex-prefixes-values: (
+    -webkit-box,
+    -moz-box,
+    -ms-flexbox,
+    -webkit-flex,
+    flex
+) !default;
+
 $justify-content-props: (
     -webkit-box-pack,
     -webkit-justify-content,

--- a/src/mixins/flex-props/main-props/_flex.scss
+++ b/src/mixins/flex-props/main-props/_flex.scss
@@ -23,7 +23,7 @@
 // @module main-props/d-flex
 
 // @dependencies:
-// * - Nothing.
+// * - var.$flex-prefixes-values (variable).
 
 // @example
 // * .example {
@@ -39,10 +39,10 @@
 // *   display: flex;
 // * }
 
-@mixin d-flex() {
-    $flex-prefixes-values: (-webkit-box, -moz-box, -ms-flexbox, -webkit-flex, flex) !default;
+@use "../../../abstract/global-variables" as var;
 
-    @each $flex-val in $flex-prefixes-values {
+@mixin d-flex() {
+    @each $flex-val in var.$flex-prefixes-values {
         display: $flex-val;
     }
 }


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `$flex-prefixes-values` in `_global-variables.scss` file to be a global map variable.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
