### PR TITLE
Add `documentations` for `flex-between-*` mixins in tests

### DIFF
--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-baseline.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-baseline.test.scss
@@ -1,3 +1,32 @@
+@charset "UTF-8";
+
+// @description
+// * flex-between-baseline mixin.
+// * This module tests a flex-between-baseline mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/between
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-between-baseline (mixin).
+
 @use "sass:map";
 @use "true" as *;
 @use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-center.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-center.test.scss
@@ -1,3 +1,32 @@
+@charset "UTF-8";
+
+// @description
+// * flex-between-center mixin.
+// * This module tests a flex-between-center mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/between
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-between-center (mixin).
+
 @use "sass:map";
 @use "true" as *;
 @use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-end.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-end.test.scss
@@ -1,3 +1,32 @@
+@charset "UTF-8";
+
+// @description
+// * flex-between-end mixin.
+// * This module tests a flex-between-end mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/between
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-between-end (mixin).
+
 @use "sass:map";
 @use "true" as *;
 @use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-fend.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-fend.test.scss
@@ -1,3 +1,32 @@
+@charset "UTF-8";
+
+// @description
+// * flex-between-fend mixin.
+// * This module tests a flex-between-fend mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/between
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-between-fend (mixin).
+
 @use "sass:map";
 @use "true" as *;
 @use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-fstart.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-fstart.test.scss
@@ -1,3 +1,32 @@
+@charset "UTF-8";
+
+// @description
+// * flex-between-fstart mixin.
+// * This module tests a flex-between-fstart mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/between
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-between-fstart (mixin).
+
 @use "sass:map";
 @use "true" as *;
 @use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-inherit.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-inherit.test.scss
@@ -1,3 +1,32 @@
+@charset "UTF-8";
+
+// @description
+// * flex-between-inh mixin.
+// * This module tests a flex-between-inh mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/between
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-between-inh (mixin).
+
 @use "sass:map";
 @use "true" as *;
 @use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-normal.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-normal.test.scss
@@ -1,3 +1,32 @@
+@charset "UTF-8";
+
+// @description
+// * flex-between-normal mixin.
+// * This module tests a flex-between-normal mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/between
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-between-normal (mixin).
+
 @use "sass:map";
 @use "true" as *;
 @use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-start.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-start.test.scss
@@ -1,3 +1,32 @@
+@charset "UTF-8";
+
+// @description
+// * flex-between-start mixin.
+// * This module tests a flex-between-start mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/between
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-between-start (mixin).
+
 @use "sass:map";
 @use "true" as *;
 @use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;

--- a/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-stretch.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-between/_flex-between-stretch.test.scss
@@ -1,3 +1,32 @@
+@charset "UTF-8";
+
+// @description
+// * flex-between-stretch mixin.
+// * This module tests a flex-between-stretch mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/between
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-between-stretch (mixin).
+
 @use "sass:map";
 @use "true" as *;
 @use "../../../../../src/mixins/flex-props/flexbox/between" as LibMixin;


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `documentation` for `flex-between-baseline` mixin in `tests`.
- Add `documentation` for `flex-between-center` mixin in `tests`.
- Add `documentation` for `flex-between-end` mixin in `tests`.
- Add `documentation` for `flex-between-fend` mixin in `tests`.
- Add `documentation` for `flex-between-fstart` mixin in `tests`.
- Add `documentation` for `flex-between-inh` mixin in `tests`.
- Add `documentation` for `flex-between-normal` mixin in `tests`.
- Add `documentation` for `flex-between-start` mixin in `tests`.
- Add `documentation` for `flex-between-stretch` mixin in `tests`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
