### PR TITLE
Add `unit test` for `flex-right-*` mixins

### DIFF
--- a/tests/mixins/flex-props/flexbox/_index.scss
+++ b/tests/mixins/flex-props/flexbox/_index.scss
@@ -70,3 +70,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flexbox-left
 @forward "flexbox-left";
+
+// * forwarding the "flexbox-right" module.
+// * The "flexbox-right" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flexbox-right
+@forward "flexbox-right";

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-baseline.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-baseline.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * flex-right-baseline mixin.
+// * This module tests a flex-right-baseline mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-right-baseline (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/right" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-right-baseline-map: (
+    ".test-case-1": (
+        selector: ".test-flex-right-baseline-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-right-baseline-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-right-baseline-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-right-baseline-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-right-baseline-map {
+    @include describe("[Mixin] flex-right-baseline") {
+        @include it("should output correct flex-right-baseline values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-right-baseline(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-center.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-center.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * flex-right-center mixin.
+// * This module tests a flex-right-center mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-right-center (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/right" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-right-center-map: (
+    ".test-case-1": (
+        selector: ".test-flex-right-center-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-right-center-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-right-center-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-right-center-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-right-center-map {
+    @include describe("[Mixin] flex-right-center") {
+        @include it("should output correct flex-right-center values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-right-center(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-end.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-end.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * flex-right-end mixin.
+// * This module tests a flex-right-end mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-right-end (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/right" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-right-end-map: (
+    ".test-case-1": (
+        selector: ".test-flex-right-end-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-right-end-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-right-end-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-right-end-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-right-end-map {
+    @include describe("[Mixin] flex-right-end") {
+        @include it("should output correct flex-right-end values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-right-end(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-fend.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-fend.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * flex-right-fend mixin.
+// * This module tests a flex-right-fend mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-right-fend (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/right" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-right-fend-map: (
+    ".test-case-1": (
+        selector: ".test-flex-right-fend-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-right-fend-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-right-fend-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-right-fend-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-right-fend-map {
+    @include describe("[Mixin] flex-right-fend") {
+        @include it("should output correct flex-right-fend values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-right-fend(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-fstart.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-fstart.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * flex-right-fstart mixin.
+// * This module tests a flex-right-fstart mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-right-fstart (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/right" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-right-fstart-map: (
+    ".test-case-1": (
+        selector: ".test-flex-right-fstart-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-right-fstart-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-right-fstart-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-right-fstart-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-right-fstart-map {
+    @include describe("[Mixin] flex-right-fstart") {
+        @include it("should output correct flex-right-fstart values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-right-fstart(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-inherit.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-inherit.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * flex-right-inh mixin.
+// * This module tests a flex-right-inh mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-right-inh (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/right" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-right-inh-map: (
+    ".test-case-1": (
+        selector: ".test-flex-right-inh-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-right-inh-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-right-inh-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-right-inh-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-right-inh-map {
+    @include describe("[Mixin] flex-right-inh") {
+        @include it("should output correct flex-right-inh values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-right-inh(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-normal.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-normal.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * flex-right-normal mixin.
+// * This module tests a flex-right-normal mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-right-normal (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/right" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-right-normal-map: (
+    ".test-case-1": (
+        selector: ".test-flex-right-normal-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-right-normal-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-right-normal-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-right-normal-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-right-normal-map {
+    @include describe("[Mixin] flex-right-normal") {
+        @include it("should output correct flex-right-normal values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-right-normal(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-start.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-start.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * flex-right-start mixin.
+// * This module tests a flex-right-start mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-right-start (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/right" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-right-start-map: (
+    ".test-case-1": (
+        selector: ".test-flex-right-start-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-right-start-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-right-start-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-right-start-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-right-start-map {
+    @include describe("[Mixin] flex-right-start") {
+        @include it("should output correct flex-right-start values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-right-start(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-stretch.test.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_flex-right-stretch.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * flex-right-stretch mixin.
+// * This module tests a flex-right-stretch mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.flex-right-stretch (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/flexbox/right" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-flex-right-stretch-map: (
+    ".test-case-1": (
+        selector: ".test-flex-right-stretch-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-flex-right-stretch-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-flex-right-stretch-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-flex-right-stretch-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: right,
+            -webkit-justify-content: right,
+            -ms-flex-pack: right,
+            -moz-justify-content: right,
+            justify-content: right,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-flex-right-stretch-map {
+    @include describe("[Mixin] flex-right-stretch") {
+        @include it("should output correct flex-right-stretch values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.flex-right-stretch(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-box;
+                        display: -moz-box;
+                        display: -ms-flexbox;
+                        display: -webkit-flex;
+                        display: flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
@@ -58,3 +58,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flex-right-start.test
 @forward "./flex-right-start.test";
+
+// * forwarding the "flex-right-stretch.test" module.
+// * The "flex-right-stretch.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-right-stretch.test
+@forward "./flex-right-stretch.test";

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
@@ -16,3 +16,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flex-right-baseline.test
 @forward "./flex-right-baseline.test";
+
+// * forwarding the "flex-right-center.test" module.
+// * The "flex-right-center.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-right-center.test
+@forward "./flex-right-center.test";

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
@@ -28,3 +28,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flex-right-end.test
 @forward "./flex-right-end.test";
+
+// * forwarding the "flex-right-fend.test" module.
+// * The "flex-right-fend.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-right-fend.test
+@forward "./flex-right-fend.test";

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
@@ -40,3 +40,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flex-right-fstart.test
 @forward "./flex-right-fstart.test";
+
+// * forwarding the "flex-right-inherit.test" module.
+// * The "flex-right-inherit.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-right-inherit.test
+@forward "./flex-right-inherit.test";

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
@@ -34,3 +34,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flex-right-fend.test
 @forward "./flex-right-fend.test";
+
+// * forwarding the "flex-right-fstart.test" module.
+// * The "flex-right-fstart.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-right-fstart.test
+@forward "./flex-right-fstart.test";

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases for justify-content with value right.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "flex-right-baseline.test" module.
+// * The "flex-right-baseline.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-right-baseline.test
+@forward "./flex-right-baseline.test";

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
@@ -46,3 +46,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flex-right-inherit.test
 @forward "./flex-right-inherit.test";
+
+// * forwarding the "flex-right-normal.test" module.
+// * The "flex-right-normal.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-right-normal.test
+@forward "./flex-right-normal.test";

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
@@ -52,3 +52,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flex-right-normal.test
 @forward "./flex-right-normal.test";
+
+// * forwarding the "flex-right-start.test" module.
+// * The "flex-right-start.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-right-start.test
+@forward "./flex-right-start.test";

--- a/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
+++ b/tests/mixins/flex-props/flexbox/flexbox-right/_index.scss
@@ -22,3 +22,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see flex-right-center.test
 @forward "./flex-right-center.test";
+
+// * forwarding the "flex-right-end.test" module.
+// * The "flex-right-end.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see flex-right-end.test
+@forward "./flex-right-end.test";


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `unit test` for `flex-right-baseline` mixin to handle all `test cases`.
- Add `unit test` for `flex-right-center` mixin to handle all `test cases`.
- Add `unit test` for `flex-right-end` mixin to handle all `test cases`.
- Add `unit test` for `flex-right-fend` mixin to handle all `test cases`.
- Add `unit test` for `flex-right-fstart` mixin to handle all `test cases`.
- Add `unit test` for `flex-right-inh` mixin to handle all `test cases`.
- Add `unit test` for `flex-right-normal` mixin to handle all `test cases`.
- Add `unit test` for `flex-right-start` mixin to handle all `test cases`.
- Add `unit test` for `flex-right-stretch` mixin to handle all `test cases`.
- Add `_index.scss` file to `use` all the previous files.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
