### PR TITLE
fix(mixins-logical-props): :bug: fix order of properties in `overflow-x` mixin

### DIFF
--- a/src/mixins/logical-props/_overflow-x.scss
+++ b/src/mixins/logical-props/_overflow-x.scss
@@ -47,8 +47,8 @@
         content: Error.throw("The parameter of overflow-x mixin must be in a string type.");
     } @else {
         @if list.index(var.$overflow-values, $value) {
-            overflow-inline: $value;
             overflow-x: $value;
+            overflow-inline: $value;
         } @else {
             content: Error.throw("The parameter of overflow-x mixin must be one of these values: (#{var.$overflow-values}).");
         }


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Fix the order of properties by introducing the `overflow-x` CSS property over `overflow-inline` CSS property.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
