### PR TITLE
fix(mixins-grid-props): :art: add `$inline-grid-prefixes-values` as global var

### DIFF
--- a/src/abstract/_global-variables.scss
+++ b/src/abstract/_global-variables.scss
@@ -238,6 +238,11 @@ $flex-grow-values: (
     unset,
 ) !default;
 
+$inline-grid-prefixes-values: (
+    -ms-inline-grid,
+    inline-grid
+) !default;
+
 $column-gap-props: (
     -webkit-column-gap,
     -moz-column-gap,

--- a/src/mixins/grid-props/_inline-grid.scss
+++ b/src/mixins/grid-props/_inline-grid.scss
@@ -8,7 +8,7 @@
 
 // @access public
 
-// @version 1.1.0
+// @version 1.1.1
 
 // @author Khaled Mohamed
 
@@ -23,7 +23,7 @@
 // @module grid/d-ingrid
 
 // @dependencies:
-// * - Nothing.
+// * - var.$inline-grid-prefixes-values (variable).
 
 // @example
 // * .example {
@@ -36,10 +36,10 @@
 // *   display: inline-grid;
 // * }
 
-@mixin d-ingrid() {
-    $inline-grid-prefixes-values: (-ms-inline-grid, inline-grid) !default;
+@use "../../abstract/global-variables" as var;
 
-    @each $value in $inline-grid-prefixes-values {
+@mixin d-ingrid() {
+    @each $value in var.$inline-grid-prefixes-values {
         display: #{$value};
     }
 }


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `$inline-grid-prefixes-values` variable in `src/abstract/_global-variables.scss` path.
- Refactor the `d-ingrid` mixin to handle the movement of `$inline-grid-prefixes-values` variable.
- Update the `dependencies` in `src/mixins/grid-props/_inline-grid.scss` file.
- Update the `version` in `src/mixins/grid-props/_inline-grid.scss` file.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
