### PR TITLE
test(tests): :white_check_mark: move local variables in `text-align-last` mixin to be global vars & add `unit test` for `text-align-last` mixin

### DIFF
--- a/src/abstract/_global-variables.scss
+++ b/src/abstract/_global-variables.scss
@@ -285,6 +285,26 @@ $grid-row-end: (
     grid-row-end,
 ) !default;
 
+$text-align-last-props: (
+    -moz-text-align-last,
+    text-align-last
+) !default;
+
+$text-align-last-props-values: (
+    auto,
+    start,
+    end,
+    left,
+    right,
+    center,
+    justify,
+    inherit,
+    initial,
+    revert,
+    revert-layer,
+    unset
+) !default;
+
 $neutral-colors-light-map: (
     50: hsl(0, 0%, 100%),
     100: hsl(0, 0%, 95%),

--- a/src/mixins/typography/_text-align-last.scss
+++ b/src/mixins/typography/_text-align-last.scss
@@ -7,7 +7,7 @@
 
 // @access public
 
-// @version 1.0.0
+// @version 1.0.1
 
 // @author Khaled Mohamed
 
@@ -24,6 +24,8 @@
 // @dependencies:
 // * - meta.type-of (SASS function).
 // * - LibFunc.is-in-list (function).
+// * - var.var.$text-align-last-props (variable).
+// * - var.var.$text-align-last-props-values (variable).
 // * - Error.throw (function).
 
 // @param {String} $value
@@ -47,39 +49,19 @@
 @use "sass:meta";
 @use "sass:list";
 @use "../../functions/global/is-in-list" as LibFunc;
+@use "../../abstract/global-variables" as var;
 @use "../../development-utils/toggle-error-message" as Error;
 
 @mixin text-align-last($value: auto) {
-    $text-align-last-props: (
-        -moz-text-align-last,
-        text-align-last
-    ) !default;
-
-    // * stylelint-disable-next-line scss/dollar-variable-empty-line-before
-    $text-align-last-props-values: (
-        auto,
-        start,
-        end,
-        left,
-        right,
-        center,
-        justify,
-        inherit,
-        initial,
-        revert,
-        revert-layer,
-        unset
-    ) !default;
-
     @if meta.type-of($value) == string {
-        @if LibFunc.is-in-list($text-align-last-props-values, $value) {
-            @each $prop in $text-align-last-props {
+        @if LibFunc.is-in-list(var.$text-align-last-props-values, $value) {
+            @each $prop in var.$text-align-last-props {
                 #{$prop}: $value;
             }
         } @else {
-            content: Error.throw("The parameter of text-align-last mixin must has one of these values: (#{$text-align-last-props-values}).");
+            content: Error.throw("The parameter of text-align-last mixin must has one of these values: (#{var.$text-align-last-props-values}).");
         }
     } @else {
-        content: Error.throw("The parameter of text-align-last mixin must has one of these values: (#{$text-align-last-props-values}).");
+        content: Error.throw("The parameter of text-align-last mixin must has one of these values: (#{var.$text-align-last-props-values}).");
     }
 }

--- a/tests/mixins/_index.scss
+++ b/tests/mixins/_index.scss
@@ -40,3 +40,9 @@
 // * grid-props module.
 // @see grid-props
 @forward "grid-props";
+
+// * forwarding the "typography" module.
+// * The "typography" module likely provides a test cases for
+// * typography module.
+// @see typography
+@forward "typography";

--- a/tests/mixins/typography/_index.scss
+++ b/tests/mixins/typography/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases of typography.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "text-align-last.test" module.
+// * The "text-align-last.test" module likely provides a test cases for
+// * overflow-x with its fallback.
+// @see text-align-last.test
+@forward "text-align-last.test";

--- a/tests/mixins/typography/_text-align-last.test.scss
+++ b/tests/mixins/typography/_text-align-last.test.scss
@@ -1,0 +1,164 @@
+@charset "UTF-8";
+
+// @description
+// * text-align-last mixin.
+// * This module tests an text-align-last mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace typography
+
+// @module typography/text-align-last
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.text-align-last (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../src/mixins/typography/text-align-last" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+
+$test-cases-text-align-last-map: (
+    "test-case-1": (
+        selector: ".test-text-align-last-auto",
+        value: auto,
+        expected: (
+            -moz-text-align-last: auto,
+            text-align-last: auto,
+        ),
+    ),
+    "test-case-2": (
+        selector: ".test-text-align-last-start",
+        value: start,
+        expected: (
+            -moz-text-align-last: start,
+            text-align-last: start,
+        ),
+    ),
+    "test-case-3": (
+        selector: ".test-text-align-last-end",
+        value: end,
+        expected: (
+            -moz-text-align-last: end,
+            text-align-last: end,
+        ),
+    ),
+    "test-case-4": (
+        selector: ".test-text-align-last-left",
+        value: left,
+        expected: (
+            -moz-text-align-last: left,
+            text-align-last: left,
+        ),
+    ),
+    "test-case-5": (
+        selector: ".test-text-align-last-right",
+        value: right,
+        expected: (
+            -moz-text-align-last: right,
+            text-align-last: right,
+        ),
+    ),
+    "test-case-6": (
+        selector: ".test-text-align-last-center",
+        value: center,
+        expected: (
+            -moz-text-align-last: center,
+            text-align-last: center,
+        ),
+    ),
+    "test-case-7": (
+        selector: ".test-text-align-last-justify",
+        value: justify,
+        expected: (
+            -moz-text-align-last: justify,
+            text-align-last: justify,
+        ),
+    ),
+    "test-case-8": (
+        selector: ".test-text-align-last-inherit",
+        value: inherit,
+        expected: (
+            -moz-text-align-last: inherit,
+            text-align-last: inherit,
+        ),
+    ),
+    "test-case-9": (
+        selector: ".test-text-align-last-initial",
+        value: initial,
+        expected: (
+            -moz-text-align-last: initial,
+            text-align-last: initial,
+        ),
+    ),
+    "test-case-10": (
+        selector: ".test-text-align-last-revert",
+        value: revert,
+        expected: (
+            -moz-text-align-last: revert,
+            text-align-last: revert,
+        ),
+    ),
+    "test-case-11": (
+        selector: ".test-text-align-last-revert-layer",
+        value: revert-layer,
+        expected: (
+            -moz-text-align-last: revert-layer,
+            text-align-last: revert-layer,
+        ),
+    ),
+    "test-case-12": (
+        selector: ".test-text-align-last-unset",
+        value: unset,
+        expected: (
+            -moz-text-align-last: unset,
+            text-align-last: unset,
+        ),
+    ),
+    "test-case-13": (
+        selector: ".test-text-align-last-unknown",
+        value: unknown,
+        expected: (
+            content: '"ERROR: The parameter of text-align-last mixin must has one of these values: (auto, start, end, left, right, center, justify, inherit, initial, revert, revert-layer, unset)."',
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-text-align-last-map {
+    @include describe("[Mixin] text-align-last for #{$case-name}") {
+        @include it("should output correct text-align-last properties") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.text-align-last(#{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Move `$text-align-last-props` variable from `src/mixins/typography/_text-align-last.scss` to be in `src/abstract/_global-variables.scss` path.
- Move `$text-align-last-props-values` variable from `src/mixins/typography/_text-align-last.scss` to be in `src/abstract/_global-variables.scss` path.
- Update the `dependecies` in mixin `text-align-last` in `src/mixins/typography/_text-align-last.scss` path.
- Update the `version` of `text-align-last` mixin in `src/mixins/typography/_text-align-last.scss` path.
- Add `unit tests` for `text-align-last` mixin to handle all `test cases`.
- Update the file in path `tests/mixins/_index.scss` to import the `typography` module.
- Add `tests/mixins/typography/_index.scss` to wrap all file in `typography` module.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
