### PR TITLE
test(tests): :white_check_mark: add `unit test` for `prefixing-all` mixin

### DIFF
--- a/tests/mixins/_index.scss
+++ b/tests/mixins/_index.scss
@@ -46,3 +46,9 @@
 // * typography module.
 // @see typography
 @forward "typography";
+
+// * forwarding the "vendor-prefixes" module.
+// * The "vendor-prefixes" module likely provides a test cases for
+// * vendor-prefixes module.
+// @see vendor-prefixes
+@forward "vendor-prefixes";

--- a/tests/mixins/vendor-prefixes/_index.scss
+++ b/tests/mixins/vendor-prefixes/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases of vendor prefixes.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "prefix" module.
+// * The "prefix" module likely provides a test cases for
+// * prefix for testing the vendor prefix.
+// @see prefix
+@forward "prefix";

--- a/tests/mixins/vendor-prefixes/prefix/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases of prefix.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "prefixing-all.test" module.
+// * The "prefixing-all.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefixing-all.test
+@forward "prefixing-all.test";

--- a/tests/mixins/vendor-prefixes/prefix/_prefixing-all.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix/_prefixing-all.test.scss
@@ -1,0 +1,74 @@
+@charset "UTF-8";
+
+// @description
+// * prefixing-all mixin.
+// * This module tests a prefixing-all mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefixing-all
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefixing-all (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefixing-all-map: (
+    ".test-case-1": (
+        selector: ".test-prefixing-all-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -webkit-prop-1: value-1,
+            -moz-prop-1: value-1,
+            -ms-prop-1: value-1,
+            -o-prop-1: value-1,
+            prop-1: value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefixing-all-map {
+    @include describe("[Mixin] prefixing-all") {
+        @include it("should output correct prefixing-all values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefixing-all(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Update the `tests/mixins/_index.scss` file to get the `vendor-prefixes` module.
- Add `tests/mixins/vendor-prefixes/_index.scss` path to handle the two modules `prefix` and `prefix-val`.
- Add first `test` for the `prefixing-all` mixin in `tests/mixins/vendor-prefixes/prefix/_index.scss` path.
- Add `unit test` for `prefixing-all` mixin to handle all `test cases`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
