### PR TITLE
test(tests): :white_check_mark: add `unit test` for `prefixing-moz-o` mixin

### DIFF
--- a/tests/mixins/vendor-prefixes/prefix/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix/_index.scss
@@ -40,3 +40,9 @@
 // * testing all vendor prefixes.
 // @see prefixing-web-o.test
 @forward "prefixing-web-o.test";
+
+// * forwarding the "prefixing-moz-o.test" module.
+// * The "prefixing-moz-o.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefixing-moz-o.test
+@forward "prefixing-moz-o.test";

--- a/tests/mixins/vendor-prefixes/prefix/_prefixing-moz-o.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix/_prefixing-moz-o.test.scss
@@ -1,0 +1,72 @@
+@charset "UTF-8";
+
+// @description
+// * prefixing-moz-o mixin.
+// * This module tests a prefixing-moz-o mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefixing-moz-o
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefixing-moz-o (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefixing-moz-o-map: (
+    ".test-case-1": (
+        selector: ".test-prefixing-moz-o-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -moz-prop-1: value-1,
+            -o-prop-1: value-1,
+            prop-1: value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefixing-moz-o-map {
+    @include describe("[Mixin] prefixing-moz-o") {
+        @include it("should output correct prefixing-moz-o values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefixing-moz-o(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Update the path `tests/mixins/vendor-prefixes/prefix/_index.scss` to import the `prefixing-moz-o` test mixin.
- Add `unit test` for `prefixing-moz-o` mixin to handle all `test cases`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
