### PR TITLE
test(tests): :white_check_mark: add `unit test` for `prefixing-ms-o` mixin

### DIFF
--- a/tests/mixins/vendor-prefixes/prefix/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix/_index.scss
@@ -46,3 +46,9 @@
 // * testing all vendor prefixes.
 // @see prefixing-moz-o.test
 @forward "prefixing-moz-o.test";
+
+// * forwarding the "prefixing-ms-o.test" module.
+// * The "prefixing-ms-o.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefixing-ms-o.test
+@forward "prefixing-ms-o.test";

--- a/tests/mixins/vendor-prefixes/prefix/_prefixing-ms-o.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix/_prefixing-ms-o.test.scss
@@ -1,0 +1,72 @@
+@charset "UTF-8";
+
+// @description
+// * prefixing-ms-o mixin.
+// * This module tests a prefixing-ms-o mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefixing-ms-o
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefixing-ms-o (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefixing-ms-o-map: (
+    ".test-case-1": (
+        selector: ".test-prefixing-ms-o-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -ms-prop-1: value-1,
+            -o-prop-1: value-1,
+            prop-1: value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefixing-ms-o-map {
+    @include describe("[Mixin] prefixing-ms-o") {
+        @include it("should output correct prefixing-ms-o values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefixing-ms-o(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Update the path `tests/mixins/vendor-prefixes/prefix/_index.scss` to import the `prefixing-ms-o` test mixin.
- Add `unit test` for `prefixing-ms-o` mixin to handle all `test cases`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
