### PR TITLE
test(tests): :white_check_mark: add `unit test` for `prefixing-web` mixin

### DIFF
--- a/tests/mixins/vendor-prefixes/prefix/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix/_index.scss
@@ -58,3 +58,9 @@
 // * testing all vendor prefixes.
 // @see prefixing-ms.test
 @forward "prefixing-ms.test";
+
+// * forwarding the "prefixing-web.test" module.
+// * The "prefixing-web.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefixing-web.test
+@forward "prefixing-web.test";

--- a/tests/mixins/vendor-prefixes/prefix/_prefixing-web.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix/_prefixing-web.test.scss
@@ -1,0 +1,71 @@
+@charset "UTF-8";
+
+// @description
+// * prefixing-web mixin.
+// * This module tests a prefixing-web mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefixing-web
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefixing-web (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefixing-web-map: (
+    ".test-case-1": (
+        selector: ".test-prefixing-web-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -webkit-prop-1: value-1,
+            prop-1: value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefixing-web-map {
+    @include describe("[Mixin] prefixing-web") {
+        @include it("should output correct prefixing-web values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefixing-web(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Update the path `tests/mixins/vendor-prefixes/prefix/_index.scss` to import the `prefixing-web` test mixin.
- Add `unit test` for `prefixing-web` mixin to handle all `test cases`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
