### PR TITLE
Add `unit test` for `prefix-val-*` mixins

### DIFF
--- a/tests/mixins/vendor-prefixes/_index.scss
+++ b/tests/mixins/vendor-prefixes/_index.scss
@@ -16,3 +16,9 @@
 // * prefix for testing the vendor prefix.
 // @see prefix
 @forward "prefix";
+
+// * forwarding the "prefix-val" module.
+// * The "prefix-val" module likely provides a test cases for
+// * prefix-val for testing the vendor prefix.
+// @see prefix-val
+@forward "prefix-val";

--- a/tests/mixins/vendor-prefixes/prefix-val/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_index.scss
@@ -40,3 +40,9 @@
 // * testing all vendor prefixes.
 // @see prefix-web-o.test
 @forward "prefix-val-web-o.test";
+
+// * forwarding the "prefix-moz-o.test" module.
+// * The "prefix-moz-o.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefix-moz-o.test
+@forward "prefix-val-moz-o.test";

--- a/tests/mixins/vendor-prefixes/prefix-val/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_index.scss
@@ -28,3 +28,9 @@
 // * testing all vendor prefixes.
 // @see prefix-web-moz.test
 @forward "prefix-val-web-moz.test";
+
+// * forwarding the "prefix-web-ms.test" module.
+// * The "prefix-web-ms.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefix-web-ms.test
+@forward "prefix-val-web-ms.test";

--- a/tests/mixins/vendor-prefixes/prefix-val/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_index.scss
@@ -22,3 +22,9 @@
 // * testing all vendor prefixes.
 // @see prefix-web-moz-ms.test
 @forward "prefix-val-web-moz-ms.test";
+
+// * forwarding the "prefix-web-moz.test" module.
+// * The "prefix-web-moz.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefix-web-moz.test
+@forward "prefix-val-web-moz.test";

--- a/tests/mixins/vendor-prefixes/prefix-val/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_index.scss
@@ -16,3 +16,9 @@
 // * testing all vendor prefixes.
 // @see prefix-all.test
 @forward "prefix-val-all.test";
+
+// * forwarding the "prefix-web-moz-ms.test" module.
+// * The "prefix-web-moz-ms.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefix-web-moz-ms.test
+@forward "prefix-val-web-moz-ms.test";

--- a/tests/mixins/vendor-prefixes/prefix-val/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases of prefix-val.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "prefix-all.test" module.
+// * The "prefix-all.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefix-all.test
+@forward "prefix-val-all.test";

--- a/tests/mixins/vendor-prefixes/prefix-val/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_index.scss
@@ -34,3 +34,9 @@
 // * testing all vendor prefixes.
 // @see prefix-web-ms.test
 @forward "prefix-val-web-ms.test";
+
+// * forwarding the "prefix-web-o.test" module.
+// * The "prefix-web-o.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefix-web-o.test
+@forward "prefix-val-web-o.test";

--- a/tests/mixins/vendor-prefixes/prefix-val/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_index.scss
@@ -52,3 +52,9 @@
 // * testing all vendor prefixes.
 // @see prefix-ms-o.test
 @forward "prefix-val-ms-o.test";
+
+// * forwarding the "prefix-ms.test" module.
+// * The "prefix-ms.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefix-ms.test
+@forward "prefix-val-ms.test";

--- a/tests/mixins/vendor-prefixes/prefix-val/_index.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_index.scss
@@ -46,3 +46,9 @@
 // * testing all vendor prefixes.
 // @see prefix-moz-o.test
 @forward "prefix-val-moz-o.test";
+
+// * forwarding the "prefix-ms-o.test" module.
+// * The "prefix-ms-o.test" module likely provides a test cases for
+// * testing all vendor prefixes.
+// @see prefix-ms-o.test
+@forward "prefix-val-ms-o.test";

--- a/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-all.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-all.test.scss
@@ -1,0 +1,74 @@
+@charset "UTF-8";
+
+// @description
+// * prefix-val-all mixin.
+// * This module tests a prefix-val-all mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefix-val-all
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefix-val-all (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix-val" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefix-val-all-map: (
+    ".test-case-1": (
+        selector: ".test-prefix-val-all-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -webkit-value-1,
+            -moz-value-1,
+            -ms-value-1,
+            -o-value-1,
+            value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefix-val-all-map {
+    @include describe("[Mixin] prefix-val-all") {
+        @include it("should output correct prefix-val-all values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefix-val-all(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $value in map.get($case-data, expected) {
+                            #{map.get($case-data, prop)}: $value;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-moz-o.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-moz-o.test.scss
@@ -1,0 +1,72 @@
+@charset "UTF-8";
+
+// @description
+// * prefix-val-moz-o mixin.
+// * This module tests a prefix-val-moz-o mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefix-val-moz-o
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefix-val-moz-o (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix-val" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefix-val-moz-o-map: (
+    ".test-case-1": (
+        selector: ".test-prefix-val-moz-o-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -moz-value-1,
+            -o-value-1,
+            value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefix-val-moz-o-map {
+    @include describe("[Mixin] prefix-val-moz-o") {
+        @include it("should output correct prefix-val-moz-o values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefix-val-moz-o(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $value in map.get($case-data, expected) {
+                            #{map.get($case-data, prop)}: $value;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-ms-o.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-ms-o.test.scss
@@ -1,0 +1,72 @@
+@charset "UTF-8";
+
+// @description
+// * prefix-val-ms-o mixin.
+// * This module tests a prefix-val-ms-o mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefix-val-ms-o
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefix-val-ms-o (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix-val" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefix-val-ms-o-map: (
+    ".test-case-1": (
+        selector: ".test-prefix-val-ms-o-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -ms-value-1,
+            -o-value-1,
+            value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefix-val-ms-o-map {
+    @include describe("[Mixin] prefix-val-ms-o") {
+        @include it("should output correct prefix-val-ms-o values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefix-val-ms-o(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $value in map.get($case-data, expected) {
+                            #{map.get($case-data, prop)}: $value;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-ms.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-ms.test.scss
@@ -1,0 +1,71 @@
+@charset "UTF-8";
+
+// @description
+// * prefix-val-ms mixin.
+// * This module tests a prefix-val-ms mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefix-val-ms
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefix-val-ms (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix-val" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefix-val-ms-map: (
+    ".test-case-1": (
+        selector: ".test-prefix-val-ms-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -ms-value-1,
+            value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefix-val-ms-map {
+    @include describe("[Mixin] prefix-val-ms") {
+        @include it("should output correct prefix-val-ms values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefix-val-ms(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $value in map.get($case-data, expected) {
+                            #{map.get($case-data, prop)}: $value;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-web-moz-ms.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-web-moz-ms.test.scss
@@ -1,0 +1,73 @@
+@charset "UTF-8";
+
+// @description
+// * prefix-val-web-moz-ms mixin.
+// * This module tests a prefix-val-web-moz-ms mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefix-val-web-moz-ms
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefix-val-web-moz-ms (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix-val" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefix-val-web-moz-ms-map: (
+    ".test-case-1": (
+        selector: ".test-prefix-val-web-moz-ms-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -webkit-value-1,
+            -moz-value-1,
+            -ms-value-1,
+            value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefix-val-web-moz-ms-map {
+    @include describe("[Mixin] prefix-val-web-moz-ms") {
+        @include it("should output correct prefix-val-web-moz-ms values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefix-val-web-moz-ms(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $value in map.get($case-data, expected) {
+                            #{map.get($case-data, prop)}: $value;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-web-moz.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-web-moz.test.scss
@@ -1,0 +1,72 @@
+@charset "UTF-8";
+
+// @description
+// * prefix-val-web-moz mixin.
+// * This module tests a prefix-val-web-moz mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefix-val-web-moz
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefix-val-web-moz (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix-val" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefix-val-web-moz-map: (
+    ".test-case-1": (
+        selector: ".test-prefix-val-web-moz-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -webkit-value-1,
+            -moz-value-1,
+            value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefix-val-web-moz-map {
+    @include describe("[Mixin] prefix-val-web-moz") {
+        @include it("should output correct prefix-val-web-moz values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefix-val-web-moz(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $value in map.get($case-data, expected) {
+                            #{map.get($case-data, prop)}: $value;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-web-ms.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-web-ms.test.scss
@@ -1,0 +1,72 @@
+@charset "UTF-8";
+
+// @description
+// * prefix-val-web-ms mixin.
+// * This module tests a prefix-val-web-ms mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefix-val-web-ms
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefix-val-web-ms (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix-val" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefix-val-web-ms-map: (
+    ".test-case-1": (
+        selector: ".test-prefix-val-web-ms-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -webkit-value-1,
+            -ms-value-1,
+            value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefix-val-web-ms-map {
+    @include describe("[Mixin] prefix-val-web-ms") {
+        @include it("should output correct prefix-val-web-ms values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefix-val-web-ms(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $value in map.get($case-data, expected) {
+                            #{map.get($case-data, prop)}: $value;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-web-o.test.scss
+++ b/tests/mixins/vendor-prefixes/prefix-val/_prefix-val-web-o.test.scss
@@ -1,0 +1,72 @@
+@charset "UTF-8";
+
+// @description
+// * prefix-val-web-o mixin.
+// * This module tests a prefix-val-web-o mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace prefix
+
+// @module prefix/prefix-val-web-o
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.prefix-val-web-o (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../src/mixins/vendor-prefixes/prefix-val" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-prefix-val-web-o-map: (
+    ".test-case-1": (
+        selector: ".test-prefix-val-web-o-prop-1-value1-mixin",
+        prop: prop-1,
+        value: value-1,
+        expected: (
+            -webkit-value-1,
+            -o-value-1,
+            value-1,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-prefix-val-web-o-map {
+    @include describe("[Mixin] prefix-val-web-o") {
+        @include it("should output correct prefix-val-web-o values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.prefix-val-web-o(#{map.get($case-data, prop)}, #{map.get($case-data, value)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        @each $value in map.get($case-data, expected) {
+                            #{map.get($case-data, prop)}: $value;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Update `tests/mixins/vendor-prefixes/_index.scss` file to wrap all `prefix-val-*` module.
- Add `tests/mixins/vendor-prefixes/prefix-val/_index.scss` file to wrap all test mixins for `prefix-val-*`.
- Add `unit test` for `prefix-val-all` mixin to handle all `test cases`.
- Add `unit test` for `prefix-val-web-moz-ms` mixin to handle all `test cases`.
- Add `unit test` for `prefix-val-web-moz` mixin to handle all `test cases`.
- Add `unit test` for `prefix-val-web-ms` mixin to handle all `test cases`.
- Add `unit test` for `prefix-val-web-o` mixin to handle all `test cases`.
- Add `unit test` for `prefix-val-moz-o` mixin to handle all `test cases`.
- Add `unit test` for `prefix-val-ms-o` mixin to handle all `test cases`.
- Add `unit test` for `prefix-val-ms` mixin to handle all `test cases`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
