### PR TITLE
style(abstract): :art: add missing `colons` in maps

### DIFF
--- a/src/abstract/_global-variables.scss
+++ b/src/abstract/_global-variables.scss
@@ -167,7 +167,7 @@ $flex-prefixes-values: (
     -moz-box,
     -ms-flexbox,
     -webkit-flex,
-    flex
+    flex,
 ) !default;
 
 $justify-content-props: (
@@ -287,7 +287,7 @@ $grid-row-end: (
 
 $text-align-last-props: (
     -moz-text-align-last,
-    text-align-last
+    text-align-last,
 ) !default;
 
 $text-align-last-props-values: (
@@ -302,12 +302,12 @@ $text-align-last-props-values: (
     initial,
     revert,
     revert-layer,
-    unset
+    unset,
 ) !default;
 
 $text-overflow-props: (
     -o-text-overflow,
-    text-overflow
+    text-overflow,
 ) !default;
 
 $text-overflow-props-values: (
@@ -317,7 +317,7 @@ $text-overflow-props-values: (
     initial,
     revert,
     revert-layer,
-    unset
+    unset,
 ) !default;
 
 $neutral-colors-light-map: (


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add missing the colon in the maps are existed in `src/abstract/_global-variables.scss` path.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
