### PR TITLE
Add `unit test` for `inflex-inh-*` mixins

### DIFF
--- a/tests/mixins/flex-props/_index.scss
+++ b/tests/mixins/flex-props/_index.scss
@@ -22,3 +22,9 @@
 // * flexbox with its vendor prefixes.
 // @see flexbox
 @forward "flexbox";
+
+// * forwarding the "inline-flexbox" module.
+// * The "inline-flexbox" module likely provides a test cases for
+// * inline-flexbox with its vendor prefixes.
+// @see inline-flexbox
+@forward "inline-flexbox";

--- a/tests/mixins/flex-props/inline-flexbox/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases of flex-props.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "inline-flexbox-inherit" module.
+// * The "inline-flexbox-inherit" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inline-flexbox-inherit
+@forward "inline-flexbox-inherit";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
@@ -16,3 +16,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-baseline.test
 @forward "./inflex-inherit-baseline.test";
+
+// * forwarding the "inflex-inherit-center.test" module.
+// * The "inflex-inherit-center.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-inherit-center.test
+@forward "./inflex-inherit-center.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
@@ -28,3 +28,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-end.test
 @forward "./inflex-inherit-end.test";
+
+// * forwarding the "inflex-inherit-fend.test" module.
+// * The "inflex-inherit-fend.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-inherit-fend.test
+@forward "./inflex-inherit-fend.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
@@ -58,3 +58,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-start.test
 @forward "./inflex-inherit-start.test";
+
+// * forwarding the "inflex-inherit-stretch.test" module.
+// * The "inflex-inherit-stretch.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-inherit-stretch.test
+@forward "./inflex-inherit-stretch.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
@@ -52,3 +52,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-normal.test
 @forward "./inflex-inherit-normal.test";
+
+// * forwarding the "inflex-inherit-start.test" module.
+// * The "inflex-inherit-start.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-inherit-start.test
+@forward "./inflex-inherit-start.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
@@ -13,54 +13,54 @@
 
 // * forwarding the "inflex-inherit-baseline.test" module.
 // * The "inflex-inherit-baseline.test" module likely provides a test cases for
-// * display flex, justify-content, and align-items with its vendor prefixes.
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-baseline.test
 @forward "./inflex-inherit-baseline.test";
 
 // * forwarding the "inflex-inherit-center.test" module.
 // * The "inflex-inherit-center.test" module likely provides a test cases for
-// * display flex, justify-content, and align-items with its vendor prefixes.
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-center.test
 @forward "./inflex-inherit-center.test";
 
 // * forwarding the "inflex-inherit-end.test" module.
 // * The "inflex-inherit-end.test" module likely provides a test cases for
-// * display flex, justify-content, and align-items with its vendor prefixes.
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-end.test
 @forward "./inflex-inherit-end.test";
 
 // * forwarding the "inflex-inherit-fend.test" module.
 // * The "inflex-inherit-fend.test" module likely provides a test cases for
-// * display flex, justify-content, and align-items with its vendor prefixes.
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-fend.test
 @forward "./inflex-inherit-fend.test";
 
 // * forwarding the "inflex-inherit-fstart.test" module.
 // * The "inflex-inherit-fstart.test" module likely provides a test cases for
-// * display flex, justify-content, and align-items with its vendor prefixes.
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-fstart.test
 @forward "./inflex-inherit-fstart.test";
 
 // * forwarding the "inflex-inherit-inherit.test" module.
 // * The "inflex-inherit-inherit.test" module likely provides a test cases for
-// * display flex, justify-content, and align-items with its vendor prefixes.
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-inherit.test
 @forward "./inflex-inherit-inherit.test";
 
 // * forwarding the "inflex-inherit-normal.test" module.
 // * The "inflex-inherit-normal.test" module likely provides a test cases for
-// * display flex, justify-content, and align-items with its vendor prefixes.
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-normal.test
 @forward "./inflex-inherit-normal.test";
 
 // * forwarding the "inflex-inherit-start.test" module.
 // * The "inflex-inherit-start.test" module likely provides a test cases for
-// * display flex, justify-content, and align-items with its vendor prefixes.
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-start.test
 @forward "./inflex-inherit-start.test";
 
 // * forwarding the "inflex-inherit-stretch.test" module.
 // * The "inflex-inherit-stretch.test" module likely provides a test cases for
-// * display flex, justify-content, and align-items with its vendor prefixes.
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-stretch.test
 @forward "./inflex-inherit-stretch.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases for justify-content with value inherit.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "inflex-inherit-baseline.test" module.
+// * The "inflex-inherit-baseline.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-inherit-baseline.test
+@forward "./inflex-inherit-baseline.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
@@ -22,3 +22,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-center.test
 @forward "./inflex-inherit-center.test";
+
+// * forwarding the "inflex-inherit-end.test" module.
+// * The "inflex-inherit-end.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-inherit-end.test
+@forward "./inflex-inherit-end.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
@@ -40,3 +40,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-fstart.test
 @forward "./inflex-inherit-fstart.test";
+
+// * forwarding the "inflex-inherit-inherit.test" module.
+// * The "inflex-inherit-inherit.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-inherit-inherit.test
+@forward "./inflex-inherit-inherit.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
@@ -46,3 +46,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-inherit.test
 @forward "./inflex-inherit-inherit.test";
+
+// * forwarding the "inflex-inherit-normal.test" module.
+// * The "inflex-inherit-normal.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-inherit-normal.test
+@forward "./inflex-inherit-normal.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_index.scss
@@ -34,3 +34,9 @@
 // * display flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-inherit-fend.test
 @forward "./inflex-inherit-fend.test";
+
+// * forwarding the "inflex-inherit-fstart.test" module.
+// * The "inflex-inherit-fstart.test" module likely provides a test cases for
+// * display flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-inherit-fstart.test
+@forward "./inflex-inherit-fstart.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-baseline.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-baseline.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-inh-baseline mixin.
+// * This module tests a inflex-inh-baseline mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-inh-baseline (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-inherit" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-inh-baseline-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-inh-baseline-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-inh-baseline-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-inh-baseline-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-inh-baseline-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-inh-baseline-map {
+    @include describe("[Mixin] inflex-inh-baseline") {
+        @include it("should output correct inflex-inh-baseline values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-inh-baseline(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-center.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-center.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-inh-center mixin.
+// * This module tests a inflex-inh-center mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-inh-center (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-inherit" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-inh-center-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-inh-center-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-inh-center-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-inh-center-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-inh-center-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-inh-center-map {
+    @include describe("[Mixin] inflex-inh-center") {
+        @include it("should output correct inflex-inh-center values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-inh-center(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-end.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-end.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-inh-end mixin.
+// * This module tests a inflex-inh-end mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-inh-end (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-inherit" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-inh-end-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-inh-end-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-inh-end-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-inh-end-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-inh-end-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-inh-end-map {
+    @include describe("[Mixin] inflex-inh-end") {
+        @include it("should output correct inflex-inh-end values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-inh-end(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-fend.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-fend.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-inh-fend mixin.
+// * This module tests a inflex-inh-fend mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-inh-fend (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-inherit" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-inh-fend-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-inh-fend-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-inh-fend-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-inh-fend-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-inh-fend-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-inh-fend-map {
+    @include describe("[Mixin] inflex-inh-fend") {
+        @include it("should output correct inflex-inh-fend values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-inh-fend(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-fstart.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-fstart.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-inh-fstart mixin.
+// * This module tests a inflex-inh-fstart mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-inh-fstart (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-inherit" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-inh-fstart-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-inh-fstart-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-inh-fstart-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-inh-fstart-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-inh-fstart-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-inh-fstart-map {
+    @include describe("[Mixin] inflex-inh-fstart") {
+        @include it("should output correct inflex-inh-fstart values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-inh-fstart(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-inherit.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-inherit.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-inh-inh mixin.
+// * This module tests a inflex-inh-inh mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-inh-inh (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-inherit" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-inh-inh-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-inh-inh-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-inh-inh-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-inh-inh-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-inh-inh-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-inh-inh-map {
+    @include describe("[Mixin] inflex-inh-inh") {
+        @include it("should output correct inflex-inh-inh values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-inh-inh(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-normal.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-normal.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-inh-normal mixin.
+// * This module tests a inflex-inh-normal mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-inh-normal (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-inherit" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-inh-normal-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-inh-normal-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-inh-normal-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-inh-normal-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-inh-normal-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-inh-normal-map {
+    @include describe("[Mixin] inflex-inh-normal") {
+        @include it("should output correct inflex-inh-normal values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-inh-normal(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-start.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-start.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-inh-start mixin.
+// * This module tests a inflex-inh-start mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-inh-start (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-inherit" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-inh-start-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-inh-start-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-inh-start-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-inh-start-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-inh-start-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-inh-start-map {
+    @include describe("[Mixin] inflex-inh-start") {
+        @include it("should output correct inflex-inh-start values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-inh-start(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-stretch.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-inherit/_inflex-inherit-stretch.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-inh-stretch mixin.
+// * This module tests a inflex-inh-stretch mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-inh-stretch (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-inherit" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-inh-stretch-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-inh-stretch-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-inh-stretch-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-inh-stretch-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-inh-stretch-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: inherit,
+            -webkit-justify-content: inherit,
+            -ms-flex-pack: inherit,
+            -moz-justify-content: inherit,
+            justify-content: inherit,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-inh-stretch-map {
+    @include describe("[Mixin] inflex-inh-stretch") {
+        @include it("should output correct inflex-inh-stretch values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-inh-stretch(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `unit test` for `inflex-inh-baseline` mixin to handle all `test cases`.
- Add `unit test` for `inflex-inh-center` mixin to handle all `test cases`.
- Add `unit test` for `inflex-inh-end` mixin to handle all `test cases`.
- Add `unit test` for `inflex-inh-fend` mixin to handle all `test cases`.
- Add `unit test` for `inflex-inh-fstart` mixin to handle all `test cases`.
- Add `unit test` for `inflex-inh-inh` mixin to handle all `test cases`.
- Add `unit test` for `inflex-inh-normal` mixin to handle all `test cases`.
- Add `unit test` for `inflex-inh-start` mixin to handle all `test cases`.
- Add `unit test` for `inflex-inh-stretch` mixin to handle all `test cases`.
- Update `tests/mixins/flex-props/_index.scss` path to include `inline-flexbox` module.
- Add `tests/mixins/flex-props/inline-flexbox/_index.scss` path to include all files of `inline-flexbox`.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
