### PR TITLE
Add `unit test` for `inflex-fend-*` mixins

### DIFF
--- a/tests/mixins/flex-props/inline-flexbox/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/_index.scss
@@ -16,3 +16,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inline-flexbox-inherit
 @forward "inline-flexbox-inherit";
+
+// * forwarding the "inline-flexbox-fend" module.
+// * The "inline-flexbox-fend" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inline-flexbox-fend
+@forward "inline-flexbox-fend";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
@@ -58,3 +58,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fend-start.test
 @forward "./inflex-fend-start.test";
+
+// * forwarding the "inflex-fend-stretch.test" module.
+// * The "inflex-fend-stretch.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fend-stretch.test
+@forward "./inflex-fend-stretch.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
@@ -22,3 +22,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fend-center.test
 @forward "./inflex-fend-center.test";
+
+// * forwarding the "inflex-fend-end.test" module.
+// * The "inflex-fend-end.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fend-end.test
+@forward "./inflex-fend-end.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
@@ -34,3 +34,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fend-fend.test
 @forward "./inflex-fend-fend.test";
+
+// * forwarding the "inflex-fend-fstart.test" module.
+// * The "inflex-fend-fstart.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fend-fstart.test
+@forward "./inflex-fend-fstart.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
@@ -52,3 +52,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fend-normal.test
 @forward "./inflex-fend-normal.test";
+
+// * forwarding the "inflex-fend-start.test" module.
+// * The "inflex-fend-start.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fend-start.test
+@forward "./inflex-fend-start.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
@@ -28,3 +28,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fend-end.test
 @forward "./inflex-fend-end.test";
+
+// * forwarding the "inflex-fend-fend.test" module.
+// * The "inflex-fend-fend.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fend-fend.test
+@forward "./inflex-fend-fend.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases for justify-content with value flex-end.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "inflex-fend-baseline.test" module.
+// * The "inflex-fend-baseline.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fend-baseline.test
+@forward "./inflex-fend-baseline.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
@@ -46,3 +46,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fend-inherit.test
 @forward "./inflex-fend-inherit.test";
+
+// * forwarding the "inflex-fend-normal.test" module.
+// * The "inflex-fend-normal.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fend-normal.test
+@forward "./inflex-fend-normal.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
@@ -40,3 +40,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fend-fstart.test
 @forward "./inflex-fend-fstart.test";
+
+// * forwarding the "inflex-fend-inherit.test" module.
+// * The "inflex-fend-inherit.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fend-inherit.test
+@forward "./inflex-fend-inherit.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_index.scss
@@ -16,3 +16,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fend-baseline.test
 @forward "./inflex-fend-baseline.test";
+
+// * forwarding the "inflex-fend-center.test" module.
+// * The "inflex-fend-center.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fend-center.test
+@forward "./inflex-fend-center.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-baseline.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-baseline.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fend-baseline mixin.
+// * This module tests a inflex-fend-baseline mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fend-baseline (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fend" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fend-baseline-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fend-baseline-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fend-baseline-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fend-baseline-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fend-baseline-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fend-baseline-map {
+    @include describe("[Mixin] inflex-fend-baseline") {
+        @include it("should output correct inflex-fend-baseline values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fend-baseline(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-center.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-center.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fend-center mixin.
+// * This module tests a inflex-fend-center mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fend-center (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fend" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fend-center-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fend-center-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fend-center-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fend-center-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fend-center-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fend-center-map {
+    @include describe("[Mixin] inflex-fend-center") {
+        @include it("should output correct inflex-fend-center values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fend-center(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-end.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-end.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fend-end mixin.
+// * This module tests a inflex-fend-end mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fend-end (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fend" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fend-end-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fend-end-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fend-end-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fend-end-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fend-end-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fend-end-map {
+    @include describe("[Mixin] inflex-fend-end") {
+        @include it("should output correct inflex-fend-end values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fend-end(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-fend.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-fend.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fend-fend mixin.
+// * This module tests a inflex-fend-fend mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fend-fend (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fend" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fend-fend-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fend-fend-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fend-fend-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fend-fend-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fend-fend-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fend-fend-map {
+    @include describe("[Mixin] inflex-fend-fend") {
+        @include it("should output correct inflex-fend-fend values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fend-fend(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-fstart.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-fstart.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fend-fstart mixin.
+// * This module tests a inflex-fend-fstart mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fend-fstart (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fend" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fend-fstart-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fend-fstart-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fend-fstart-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fend-fstart-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fend-fstart-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fend-fstart-map {
+    @include describe("[Mixin] inflex-fend-fstart") {
+        @include it("should output correct inflex-fend-fstart values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fend-fstart(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-inherit.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-inherit.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fend-inh mixin.
+// * This module tests a inflex-fend-inh mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fend-inh (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fend" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fend-inh-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fend-inh-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fend-inh-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fend-inh-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fend-inh-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fend-inh-map {
+    @include describe("[Mixin] inflex-fend-inh") {
+        @include it("should output correct inflex-fend-inh values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fend-inh(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-normal.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-normal.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fend-normal mixin.
+// * This module tests a inflex-fend-normal mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fend-normal (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fend" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fend-normal-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fend-normal-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fend-normal-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fend-normal-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fend-normal-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fend-normal-map {
+    @include describe("[Mixin] inflex-fend-normal") {
+        @include it("should output correct inflex-fend-normal values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fend-normal(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-start.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-start.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fend-start mixin.
+// * This module tests a inflex-fend-start mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fend-start (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fend" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fend-start-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fend-start-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fend-start-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fend-start-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fend-start-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fend-start-map {
+    @include describe("[Mixin] inflex-fend-start") {
+        @include it("should output correct inflex-fend-start values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fend-start(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-stretch.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fend/_inflex-fend-stretch.test.scss
@@ -1,0 +1,156 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fend-stretch mixin.
+// * This module tests a inflex-fend-stretch mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/even
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fend-stretch (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fend" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fend-stretch-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fend-stretch-row-mixin",
+        direction: row,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fend-stretch-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (-webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fend-stretch-column-mixin",
+        direction: column,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fend-stretch-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (-webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-end,
+            -webkit-justify-content: flex-end,
+            -ms-flex-pack: flex-end,
+            -moz-justify-content: flex-end,
+            justify-content: flex-end,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fend-stretch-map {
+    @include describe("[Mixin] inflex-fend-stretch") {
+        @include it("should output correct inflex-fend-stretch values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fend-stretch(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `unit test` for `inflex-fend-baseline` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fend-center` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fend-end` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fend-fend` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fend-fstart` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fend-inh` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fend-normal` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fend-start` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fend-stretch` mixin to handle all `test cases`.
- Update `tests/mixins/flex-props/inline-flexbox/_index.scss` path to include all files of `inflex-fend-*` modules.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
