### PR TITLE
Add `unit tests` for `inflex-end-*` mixins

### DIFF
--- a/tests/mixins/flex-props/inline-flexbox/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/_index.scss
@@ -34,3 +34,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inline-flexbox-center
 @forward "inline-flexbox-center";
+
+// * forwarding the "inline-flexbox-end" module.
+// * The "inline-flexbox-end" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inline-flexbox-end
+@forward "inline-flexbox-end";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
@@ -46,3 +46,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-end-inherit.test
 @forward "./inflex-end-inherit.test";
+
+// * forwarding the "inflex-end-normal.test" module.
+// * The "inflex-end-normal.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-end-normal.test
+@forward "./inflex-end-normal.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases for justify-content with value end.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "inflex-end-baseline.test" module.
+// * The "inflex-end-baseline.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-end-baseline.test
+@forward "./inflex-end-baseline.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
@@ -28,3 +28,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-end-end.test
 @forward "./inflex-end-end.test";
+
+// * forwarding the "inflex-end-fend.test" module.
+// * The "inflex-end-fend.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-end-fend.test
+@forward "./inflex-end-fend.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
@@ -16,3 +16,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-end-baseline.test
 @forward "./inflex-end-baseline.test";
+
+// * forwarding the "inflex-end-center.test" module.
+// * The "inflex-end-center.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-end-center.test
+@forward "./inflex-end-center.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
@@ -52,3 +52,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-end-normal.test
 @forward "./inflex-end-normal.test";
+
+// * forwarding the "inflex-end-start.test" module.
+// * The "inflex-end-start.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-end-start.test
+@forward "./inflex-end-start.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
@@ -40,3 +40,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-end-fstart.test
 @forward "./inflex-end-fstart.test";
+
+// * forwarding the "inflex-end-inherit.test" module.
+// * The "inflex-end-inherit.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-end-inherit.test
+@forward "./inflex-end-inherit.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
@@ -58,3 +58,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-end-start.test
 @forward "./inflex-end-start.test";
+
+// * forwarding the "inflex-end-stretch.test" module.
+// * The "inflex-end-stretch.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-end-stretch.test
+@forward "./inflex-end-stretch.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
@@ -34,3 +34,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-end-fend.test
 @forward "./inflex-end-fend.test";
+
+// * forwarding the "inflex-end-fstart.test" module.
+// * The "inflex-end-fstart.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-end-fstart.test
+@forward "./inflex-end-fstart.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss
@@ -22,3 +22,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-end-center.test
 @forward "./inflex-end-center.test";
+
+// * forwarding the "inflex-end-end.test" module.
+// * The "inflex-end-end.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-end-end.test
+@forward "./inflex-end-end.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-baseline.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-baseline.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-end-baseline mixin.
+// * This module tests a inflex-end-baseline mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/end
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-end-baseline (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-end" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-end-baseline-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-end-baseline-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-end-baseline-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-end-baseline-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-end-baseline-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-end-baseline-map {
+    @include describe("[Mixin] inflex-end-baseline") {
+        @include it("should output correct inflex-end-baseline values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-end-baseline(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-center.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-center.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-end-center mixin.
+// * This module tests a inflex-end-center mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/end
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-end-center (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-end" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-end-center-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-end-center-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-end-center-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-end-center-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-end-center-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-end-center-map {
+    @include describe("[Mixin] inflex-end-center") {
+        @include it("should output correct inflex-end-center values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-end-center(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-end.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-end.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-end-end mixin.
+// * This module tests a inflex-end-end mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/end
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-end-end (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-end" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-end-end-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-end-end-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-end-end-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-end-end-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-end-end-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-end-end-map {
+    @include describe("[Mixin] inflex-end-end") {
+        @include it("should output correct inflex-end-end values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-end-end(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-fend.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-fend.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-end-fend mixin.
+// * This module tests a inflex-end-fend mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/end
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-end-fend (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-end" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-end-fend-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-end-fend-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-end-fend-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-end-fend-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-end-fend-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-end-fend-map {
+    @include describe("[Mixin] inflex-end-fend") {
+        @include it("should output correct inflex-end-fend values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-end-fend(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-fstart.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-fstart.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-end-fstart mixin.
+// * This module tests a inflex-end-fstart mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/end
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-end-fstart (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-end" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-end-fstart-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-end-fstart-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-end-fstart-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-end-fstart-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-end-fstart-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-end-fstart-map {
+    @include describe("[Mixin] inflex-end-fstart") {
+        @include it("should output correct inflex-end-fstart values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-end-fstart(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-inherit.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-inherit.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-end-inh mixin.
+// * This module tests a inflex-end-inh mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/end
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-end-inh (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-end" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-end-inh-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-end-inh-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-end-inh-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-end-inh-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-end-inh-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-end-inh-map {
+    @include describe("[Mixin] inflex-end-inh") {
+        @include it("should output correct inflex-end-inh values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-end-inh(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-normal.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-normal.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-end-normal mixin.
+// * This module tests a inflex-end-normal mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/end
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-end-normal (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-end" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-end-normal-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-end-normal-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-end-normal-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-end-normal-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-end-normal-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-end-normal-map {
+    @include describe("[Mixin] inflex-end-normal") {
+        @include it("should output correct inflex-end-normal values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-end-normal(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-start.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-start.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-end-start mixin.
+// * This module tests a inflex-end-start mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/end
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-end-start (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-end" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-end-start-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-end-start-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-end-start-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-end-start-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-end-start-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-end-start-map {
+    @include describe("[Mixin] inflex-end-start") {
+        @include it("should output correct inflex-end-start values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-end-start(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-stretch.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_inflex-end-stretch.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-end-stretch mixin.
+// * This module tests a inflex-end-stretch mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/end
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-end-stretch (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-end" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-end-stretch-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-end-stretch-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-end-stretch-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-end-stretch-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-end-stretch-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: end,
+            -webkit-justify-content: end,
+            -ms-flex-pack: end,
+            -moz-justify-content: end,
+            justify-content: end,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-end-stretch-map {
+    @include describe("[Mixin] inflex-end-stretch") {
+        @include it("should output correct inflex-end-stretch values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-end-stretch(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `unit test` for `inflex-end-center` mixin to handle all `test cases`.
- Add `unit test` for `inflex-end-end` mixin to handle all `test cases`.
- Add `unit test` for `inflex-end-fend` mixin to handle all `test cases`.
- Add `unit test` for `inflex-end-fstart` mixin to handle all `test cases`.
- Add `unit test` for `inflex-end-inh` mixin to handle all `test cases`.
- Add `unit test` for `inflex-end-normal` mixin to handle all `test cases`.
- Add `unit test` for `inflex-end-start` mixin to handle all `test cases`.
- Add `unit test` for `inflex-end-stretch` mixin to handle all `test cases`.
- Update `tests/mixins/flex-props/inline-flexbox/inline-flexbox-end/_index.scss` to include all files in the current module.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
