### PR TITLE
Add `unit tests` for `inflex-fstart-*` mixins

### DIFF
--- a/tests/mixins/flex-props/inline-flexbox/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/_index.scss
@@ -46,3 +46,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inline-flexbox-start
 @forward "inline-flexbox-start";
+
+// * forwarding the "inline-flexbox-fstart" module.
+// * The "inline-flexbox-fstart" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inline-flexbox-fstart
+@forward "inline-flexbox-fstart";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
@@ -58,3 +58,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fstart-start.test
 @forward "./inflex-fstart-start.test";
+
+// * forwarding the "inflex-fstart-stretch.test" module.
+// * The "inflex-fstart-stretch.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fstart-stretch.test
+@forward "./inflex-fstart-stretch.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
@@ -46,3 +46,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fstart-inherit.test
 @forward "./inflex-fstart-inherit.test";
+
+// * forwarding the "inflex-fstart-normal.test" module.
+// * The "inflex-fstart-normal.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fstart-normal.test
+@forward "./inflex-fstart-normal.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
@@ -28,3 +28,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fstart-end.test
 @forward "./inflex-fstart-end.test";
+
+// * forwarding the "inflex-fstart-fend.test" module.
+// * The "inflex-fstart-fend.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fstart-fend.test
+@forward "./inflex-fstart-fend.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
@@ -52,3 +52,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fstart-normal.test
 @forward "./inflex-fstart-normal.test";
+
+// * forwarding the "inflex-fstart-start.test" module.
+// * The "inflex-fstart-start.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fstart-start.test
+@forward "./inflex-fstart-start.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
@@ -22,3 +22,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fstart-center.test
 @forward "./inflex-fstart-center.test";
+
+// * forwarding the "inflex-fstart-end.test" module.
+// * The "inflex-fstart-end.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fstart-end.test
+@forward "./inflex-fstart-end.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases for justify-content with value flex-start.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "inflex-fstart-baseline.test" module.
+// * The "inflex-fstart-baseline.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fstart-baseline.test
+@forward "./inflex-fstart-baseline.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
@@ -40,3 +40,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fstart-fstart.test
 @forward "./inflex-fstart-fstart.test";
+
+// * forwarding the "inflex-fstart-inherit.test" module.
+// * The "inflex-fstart-inherit.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fstart-inherit.test
+@forward "./inflex-fstart-inherit.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
@@ -34,3 +34,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fstart-fend.test
 @forward "./inflex-fstart-fend.test";
+
+// * forwarding the "inflex-fstart-fstart.test" module.
+// * The "inflex-fstart-fstart.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fstart-fstart.test
+@forward "./inflex-fstart-fstart.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss
@@ -16,3 +16,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-fstart-baseline.test
 @forward "./inflex-fstart-baseline.test";
+
+// * forwarding the "inflex-fstart-center.test" module.
+// * The "inflex-fstart-center.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-fstart-center.test
+@forward "./inflex-fstart-center.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-baseline.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-baseline.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fstart-baseline mixin.
+// * This module tests a inflex-fstart-baseline mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/fstart
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fstart-baseline (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fstart" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fstart-baseline-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fstart-baseline-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fstart-baseline-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fstart-baseline-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fstart-baseline-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fstart-baseline-map {
+    @include describe("[Mixin] inflex-fstart-baseline") {
+        @include it("should output correct inflex-fstart-baseline values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fstart-baseline(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-center.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-center.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fstart-center mixin.
+// * This module tests a inflex-fstart-center mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/fstart
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fstart-center (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fstart" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fstart-center-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fstart-center-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fstart-center-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fstart-center-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fstart-center-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fstart-center-map {
+    @include describe("[Mixin] inflex-fstart-center") {
+        @include it("should output correct inflex-fstart-center values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fstart-center(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-end.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-end.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fstart-end mixin.
+// * This module tests a inflex-fstart-end mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/fstart
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fstart-end (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fstart" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fstart-end-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fstart-end-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fstart-end-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fstart-end-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fstart-end-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fstart-end-map {
+    @include describe("[Mixin] inflex-fstart-end") {
+        @include it("should output correct inflex-fstart-end values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fstart-end(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-fend.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-fend.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fstart-fend mixin.
+// * This module tests a inflex-fstart-fend mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/fstart
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fstart-fend (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fstart" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fstart-fend-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fstart-fend-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fstart-fend-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fstart-fend-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fstart-fend-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fstart-fend-map {
+    @include describe("[Mixin] inflex-fstart-fend") {
+        @include it("should output correct inflex-fstart-fend values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fstart-fend(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-fstart.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-fstart.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fstart-fstart mixin.
+// * This module tests a inflex-fstart-fstart mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/fstart
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fstart-fstart (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fstart" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fstart-fstart-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fstart-fstart-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fstart-fstart-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fstart-fstart-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fstart-fstart-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fstart-fstart-map {
+    @include describe("[Mixin] inflex-fstart-fstart") {
+        @include it("should output correct inflex-fstart-fstart values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fstart-fstart(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-inherit.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-inherit.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fstart-inh mixin.
+// * This module tests a inflex-fstart-inh mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/fstart
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fstart-inh (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fstart" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fstart-inh-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fstart-inh-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fstart-inh-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fstart-inh-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fstart-inh-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fstart-inh-map {
+    @include describe("[Mixin] inflex-fstart-inh") {
+        @include it("should output correct inflex-fstart-inh values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fstart-inh(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-normal.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-normal.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fstart-normal mixin.
+// * This module tests a inflex-fstart-normal mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/fstart
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fstart-normal (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fstart" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fstart-normal-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fstart-normal-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fstart-normal-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fstart-normal-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fstart-normal-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fstart-normal-map {
+    @include describe("[Mixin] inflex-fstart-normal") {
+        @include it("should output correct inflex-fstart-normal values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fstart-normal(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-start.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-start.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fstart-start mixin.
+// * This module tests a inflex-fstart-start mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/fstart
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fstart-start (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fstart" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fstart-start-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fstart-start-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fstart-start-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fstart-start-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fstart-start-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fstart-start-map {
+    @include describe("[Mixin] inflex-fstart-start") {
+        @include it("should output correct inflex-fstart-start values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fstart-start(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-stretch.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_inflex-fstart-stretch.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-fstart-stretch mixin.
+// * This module tests a inflex-fstart-stretch mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace flexbox
+
+// @module flexbox/fstart
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-fstart-stretch (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-fstart" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-fstart-stretch-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-fstart-stretch-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-fstart-stretch-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-fstart-stretch-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-fstart-stretch-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: flex-start,
+            -webkit-justify-content: flex-start,
+            -ms-flex-pack: flex-start,
+            -moz-justify-content: flex-start,
+            justify-content: flex-start,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-fstart-stretch-map {
+    @include describe("[Mixin] inflex-fstart-stretch") {
+        @include it("should output correct inflex-fstart-stretch values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-fstart-stretch(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `unit test` for `inflex-fstart-center` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fstart-end` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fstart-fend` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fstart-fstart` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fstart-inh` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fstart-normal` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fstart-start` mixin to handle all `test cases`.
- Add `unit test` for `inflex-fstart-stretch` mixin to handle all `test cases`.
- Update `tests/mixins/flex-props/inline-flexbox/inline-flexbox-fstart/_index.scss` to include all files in the current module.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
