### PR TITLE
Add `unit tests` for `inflex-left-*` mixins

### DIFF
--- a/tests/mixins/flex-props/inline-flexbox/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/_index.scss
@@ -52,3 +52,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inline-flexbox-fstart
 @forward "inline-flexbox-fstart";
+
+// * forwarding the "inline-flexbox-left" module.
+// * The "inline-flexbox-left" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inline-flexbox-left
+@forward "inline-flexbox-left";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
@@ -28,3 +28,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-left-end.test
 @forward "./inflex-left-end.test";
+
+// * forwarding the "inflex-left-fend.test" module.
+// * The "inflex-left-fend.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-left-fend.test
+@forward "./inflex-left-fend.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
@@ -46,3 +46,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-left-inherit.test
 @forward "./inflex-left-inherit.test";
+
+// * forwarding the "inflex-left-normal.test" module.
+// * The "inflex-left-normal.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-left-normal.test
+@forward "./inflex-left-normal.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases for justify-content with value left.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "inflex-left-baseline.test" module.
+// * The "inflex-left-baseline.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-left-baseline.test
+@forward "./inflex-left-baseline.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
@@ -16,3 +16,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-left-baseline.test
 @forward "./inflex-left-baseline.test";
+
+// * forwarding the "inflex-left-center.test" module.
+// * The "inflex-left-center.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-left-center.test
+@forward "./inflex-left-center.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
@@ -52,3 +52,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-left-normal.test
 @forward "./inflex-left-normal.test";
+
+// * forwarding the "inflex-left-start.test" module.
+// * The "inflex-left-start.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-left-start.test
+@forward "./inflex-left-start.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
@@ -40,3 +40,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-left-fstart.test
 @forward "./inflex-left-fstart.test";
+
+// * forwarding the "inflex-left-inherit.test" module.
+// * The "inflex-left-inherit.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-left-inherit.test
+@forward "./inflex-left-inherit.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
@@ -58,3 +58,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-left-start.test
 @forward "./inflex-left-start.test";
+
+// * forwarding the "inflex-left-stretch.test" module.
+// * The "inflex-left-stretch.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-left-stretch.test
+@forward "./inflex-left-stretch.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
@@ -22,3 +22,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-left-center.test
 @forward "./inflex-left-center.test";
+
+// * forwarding the "inflex-left-end.test" module.
+// * The "inflex-left-end.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-left-end.test
+@forward "./inflex-left-end.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss
@@ -34,3 +34,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-left-fend.test
 @forward "./inflex-left-fend.test";
+
+// * forwarding the "inflex-left-fstart.test" module.
+// * The "inflex-left-fstart.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-left-fstart.test
+@forward "./inflex-left-fstart.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-baseline.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-baseline.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-left-baseline mixin.
+// * This module tests a inflex-left-baseline mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/left
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-left-baseline (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-left" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-left-baseline-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-left-baseline-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-left-baseline-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-left-baseline-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-left-baseline-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-left-baseline-map {
+    @include describe("[Mixin] inflex-left-baseline") {
+        @include it("should output correct inflex-left-baseline values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-left-baseline(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-center.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-center.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-left-center mixin.
+// * This module tests a inflex-left-center mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/left
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-left-center (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-left" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-left-center-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-left-center-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-left-center-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-left-center-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-left-center-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-left-center-map {
+    @include describe("[Mixin] inflex-left-center") {
+        @include it("should output correct inflex-left-center values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-left-center(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-end.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-end.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-left-end mixin.
+// * This module tests a inflex-left-end mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/left
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-left-end (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-left" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-left-end-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-left-end-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-left-end-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-left-end-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-left-end-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-left-end-map {
+    @include describe("[Mixin] inflex-left-end") {
+        @include it("should output correct inflex-left-end values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-left-end(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-fend.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-fend.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-left-fend mixin.
+// * This module tests a inflex-left-fend mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/left
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-left-fend (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-left" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-left-fend-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-left-fend-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-left-fend-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-left-fend-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-left-fend-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-left-fend-map {
+    @include describe("[Mixin] inflex-left-fend") {
+        @include it("should output correct inflex-left-fend values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-left-fend(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-fstart.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-fstart.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-left-fstart mixin.
+// * This module tests a inflex-left-fstart mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/left
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-left-fstart (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-left" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-left-fstart-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-left-fstart-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-left-fstart-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-left-fstart-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-left-fstart-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-left-fstart-map {
+    @include describe("[Mixin] inflex-left-fstart") {
+        @include it("should output correct inflex-left-fstart values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-left-fstart(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-inherit.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-inherit.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-left-inh mixin.
+// * This module tests a inflex-left-inh mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/left
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-left-inh (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-left" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-left-inh-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-left-inh-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-left-inh-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-left-inh-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-left-inh-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-left-inh-map {
+    @include describe("[Mixin] inflex-left-inh") {
+        @include it("should output correct inflex-left-inh values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-left-inh(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-normal.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-normal.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-left-normal mixin.
+// * This module tests a inflex-left-normal mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/left
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-left-normal (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-left" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-left-normal-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-left-normal-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-left-normal-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-left-normal-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-left-normal-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-left-normal-map {
+    @include describe("[Mixin] inflex-left-normal") {
+        @include it("should output correct inflex-left-normal values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-left-normal(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-start.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-start.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-left-start mixin.
+// * This module tests a inflex-left-start mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/left
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-left-start (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-left" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-left-start-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-left-start-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-left-start-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-left-start-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-left-start-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-left-start-map {
+    @include describe("[Mixin] inflex-left-start") {
+        @include it("should output correct inflex-left-start values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-left-start(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-stretch.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_inflex-left-stretch.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-left-stretch mixin.
+// * This module tests a inflex-left-stretch mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/left
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-left-stretch (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-left" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-left-stretch-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-left-stretch-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-left-stretch-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-left-stretch-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-left-stretch-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: left,
+            -webkit-justify-content: left,
+            -ms-flex-pack: left,
+            -moz-justify-content: left,
+            justify-content: left,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-left-stretch-map {
+    @include describe("[Mixin] inflex-left-stretch") {
+        @include it("should output correct inflex-left-stretch values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-left-stretch(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `unit test` for `inflex-left-center` mixin to handle all `test cases`.
- Add `unit test` for `inflex-left-end` mixin to handle all `test cases`.
- Add `unit test` for `inflex-left-fend` mixin to handle all `test cases`.
- Add `unit test` for `inflex-left-fstart` mixin to handle all `test cases`.
- Add `unit test` for `inflex-left-inh` mixin to handle all `test cases`.
- Add `unit test` for `inflex-left-normal` mixin to handle all `test cases`.
- Add `unit test` for `inflex-left-start` mixin to handle all `test cases`.
- Add `unit test` for `inflex-left-stretch` mixin to handle all `test cases`.
- Update `tests/mixins/flex-props/inline-flexbox/inline-flexbox-left/_index.scss` to include all files in the current module.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
