### PR TITLE
Add `unit tests` for `inflex-normal-*` mixins

### DIFF
--- a/tests/mixins/flex-props/inline-flexbox/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/_index.scss
@@ -64,3 +64,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inline-flexbox-right
 @forward "inline-flexbox-right";
+
+// * forwarding the "inline-flexbox-normal" module.
+// * The "inline-flexbox-normal" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inline-flexbox-normal
+@forward "inline-flexbox-normal";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
@@ -28,3 +28,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-normal-end.test
 @forward "./inflex-normal-end.test";
+
+// * forwarding the "inflex-normal-fend.test" module.
+// * The "inflex-normal-fend.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-normal-fend.test
+@forward "./inflex-normal-fend.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
@@ -58,3 +58,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-normal-start.test
 @forward "./inflex-normal-start.test";
+
+// * forwarding the "inflex-normal-stretch.test" module.
+// * The "inflex-normal-stretch.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-normal-stretch.test
+@forward "./inflex-normal-stretch.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
@@ -52,3 +52,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-normal-normal.test
 @forward "./inflex-normal-normal.test";
+
+// * forwarding the "inflex-normal-start.test" module.
+// * The "inflex-normal-start.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-normal-start.test
+@forward "./inflex-normal-start.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
@@ -34,3 +34,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-normal-fend.test
 @forward "./inflex-normal-fend.test";
+
+// * forwarding the "inflex-normal-fstart.test" module.
+// * The "inflex-normal-fstart.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-normal-fstart.test
+@forward "./inflex-normal-fstart.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
@@ -46,3 +46,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-normal-inherit.test
 @forward "./inflex-normal-inherit.test";
+
+// * forwarding the "inflex-normal-normal.test" module.
+// * The "inflex-normal-normal.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-normal-normal.test
+@forward "./inflex-normal-normal.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
@@ -16,3 +16,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-normal-baseline.test
 @forward "./inflex-normal-baseline.test";
+
+// * forwarding the "inflex-normal-center.test" module.
+// * The "inflex-normal-center.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-normal-center.test
+@forward "./inflex-normal-center.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
@@ -22,3 +22,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-normal-center.test
 @forward "./inflex-normal-center.test";
+
+// * forwarding the "inflex-normal-end.test" module.
+// * The "inflex-normal-end.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-normal-end.test
+@forward "./inflex-normal-end.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
@@ -40,3 +40,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-normal-fstart.test
 @forward "./inflex-normal-fstart.test";
+
+// * forwarding the "inflex-normal-inherit.test" module.
+// * The "inflex-normal-inherit.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-normal-inherit.test
+@forward "./inflex-normal-inherit.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases for justify-content with value normal.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "inflex-normal-baseline.test" module.
+// * The "inflex-normal-baseline.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-normal-baseline.test
+@forward "./inflex-normal-baseline.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-baseline.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-baseline.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-normal-baseline mixin.
+// * This module tests a inflex-normal-baseline mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/normal
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-normal-baseline (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-normal" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-normal-baseline-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-normal-baseline-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-normal-baseline-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-normal-baseline-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-normal-baseline-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-normal-baseline-map {
+    @include describe("[Mixin] inflex-normal-baseline") {
+        @include it("should output correct inflex-normal-baseline values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-normal-baseline(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-center.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-center.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-normal-center mixin.
+// * This module tests a inflex-normal-center mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/normal
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-normal-center (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-normal" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-normal-center-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-normal-center-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-normal-center-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-normal-center-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-normal-center-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-normal-center-map {
+    @include describe("[Mixin] inflex-normal-center") {
+        @include it("should output correct inflex-normal-center values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-normal-center(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-end.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-end.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-normal-end mixin.
+// * This module tests a inflex-normal-end mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/normal
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-normal-end (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-normal" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-normal-end-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-normal-end-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-normal-end-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-normal-end-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-normal-end-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-normal-end-map {
+    @include describe("[Mixin] inflex-normal-end") {
+        @include it("should output correct inflex-normal-end values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-normal-end(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-fend.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-fend.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-normal-fend mixin.
+// * This module tests a inflex-normal-fend mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/normal
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-normal-fend (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-normal" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-normal-fend-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-normal-fend-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-normal-fend-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-normal-fend-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-normal-fend-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-normal-fend-map {
+    @include describe("[Mixin] inflex-normal-fend") {
+        @include it("should output correct inflex-normal-fend values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-normal-fend(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-fstart.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-fstart.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-normal-fstart mixin.
+// * This module tests a inflex-normal-fstart mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/normal
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-normal-fstart (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-normal" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-normal-fstart-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-normal-fstart-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-normal-fstart-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-normal-fstart-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-normal-fstart-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-normal-fstart-map {
+    @include describe("[Mixin] inflex-normal-fstart") {
+        @include it("should output correct inflex-normal-fstart values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-normal-fstart(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-inherit.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-inherit.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-normal-inh mixin.
+// * This module tests a inflex-normal-inh mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/normal
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-normal-inh (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-normal" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-normal-inh-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-normal-inh-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-normal-inh-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-normal-inh-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-normal-inh-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-normal-inh-map {
+    @include describe("[Mixin] inflex-normal-inh") {
+        @include it("should output correct inflex-normal-inh values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-normal-inh(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-normal.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-normal.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-normal-normal mixin.
+// * This module tests a inflex-normal-normal mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/normal
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-normal-normal (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-normal" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-normal-normal-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-normal-normal-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-normal-normal-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-normal-normal-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-normal-normal-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-normal-normal-map {
+    @include describe("[Mixin] inflex-normal-normal") {
+        @include it("should output correct inflex-normal-normal values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-normal-normal(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-start.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-start.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-normal-start mixin.
+// * This module tests a inflex-normal-start mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/normal
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-normal-start (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-normal" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-normal-start-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-normal-start-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-normal-start-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-normal-start-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-normal-start-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-normal-start-map {
+    @include describe("[Mixin] inflex-normal-start") {
+        @include it("should output correct inflex-normal-start values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-normal-start(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-stretch.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_inflex-normal-stretch.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-normal-stretch mixin.
+// * This module tests a inflex-normal-stretch mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/normal
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-normal-stretch (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-normal" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-normal-stretch-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-normal-stretch-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-normal-stretch-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-normal-stretch-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-normal-stretch-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: normal,
+            -webkit-justify-content: normal,
+            -ms-flex-pack: normal,
+            -moz-justify-content: normal,
+            justify-content: normal,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-normal-stretch-map {
+    @include describe("[Mixin] inflex-normal-stretch") {
+        @include it("should output correct inflex-normal-stretch values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-normal-stretch(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `unit test` for `inflex-normal-center` mixin to handle all `test cases`.
- Add `unit test` for `inflex-normal-end` mixin to handle all `test cases`.
- Add `unit test` for `inflex-normal-fend` mixin to handle all `test cases`.
- Add `unit test` for `inflex-normal-fstart` mixin to handle all `test cases`.
- Add `unit test` for `inflex-normal-inh` mixin to handle all `test cases`.
- Add `unit test` for `inflex-normal-normal` mixin to handle all `test cases`.
- Add `unit test` for `inflex-normal-start` mixin to handle all `test cases`.
- Add `unit test` for `inflex-normal-stretch` mixin to handle all `test cases`.
- Update `tests/mixins/flex-props/inline-flexbox/inline-flexbox-normal/_index.scss` to include all files in the current module.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
