### PR TITLE
Add `unit tests` for `inflex-stretch-*` mixins

### DIFF
--- a/tests/mixins/flex-props/inline-flexbox/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/_index.scss
@@ -70,3 +70,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inline-flexbox-normal
 @forward "inline-flexbox-normal";
+
+// * forwarding the "inline-flexbox-stretch" module.
+// * The "inline-flexbox-stretch" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inline-flexbox-stretch
+@forward "inline-flexbox-stretch";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
@@ -40,3 +40,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-stretch-fstart.test
 @forward "./inflex-stretch-fstart.test";
+
+// * forwarding the "inflex-stretch-inherit.test" module.
+// * The "inflex-stretch-inherit.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-stretch-inherit.test
+@forward "./inflex-stretch-inherit.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
@@ -52,3 +52,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-stretch-normal.test
 @forward "./inflex-stretch-normal.test";
+
+// * forwarding the "inflex-stretch-start.test" module.
+// * The "inflex-stretch-start.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-stretch-start.test
+@forward "./inflex-stretch-start.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
@@ -46,3 +46,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-stretch-inherit.test
 @forward "./inflex-stretch-inherit.test";
+
+// * forwarding the "inflex-stretch-normal.test" module.
+// * The "inflex-stretch-normal.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-stretch-normal.test
+@forward "./inflex-stretch-normal.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
@@ -28,3 +28,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-stretch-end.test
 @forward "./inflex-stretch-end.test";
+
+// * forwarding the "inflex-stretch-fend.test" module.
+// * The "inflex-stretch-fend.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-stretch-fend.test
+@forward "./inflex-stretch-fend.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
@@ -58,3 +58,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-stretch-start.test
 @forward "./inflex-stretch-start.test";
+
+// * forwarding the "inflex-stretch-stretch.test" module.
+// * The "inflex-stretch-stretch.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-stretch-stretch.test
+@forward "./inflex-stretch-stretch.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
@@ -16,3 +16,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-stretch-baseline.test
 @forward "./inflex-stretch-baseline.test";
+
+// * forwarding the "inflex-stretch-center.test" module.
+// * The "inflex-stretch-center.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-stretch-center.test
+@forward "./inflex-stretch-center.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
@@ -34,3 +34,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-stretch-fend.test
 @forward "./inflex-stretch-fend.test";
+
+// * forwarding the "inflex-stretch-fstart.test" module.
+// * The "inflex-stretch-fstart.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-stretch-fstart.test
+@forward "./inflex-stretch-fstart.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+
+// @description
+// * This file as index for test cases for justify-content with value stretch.
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace mixins
+
+// * forwarding the "inflex-stretch-baseline.test" module.
+// * The "inflex-stretch-baseline.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-stretch-baseline.test
+@forward "./inflex-stretch-baseline.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss
@@ -22,3 +22,9 @@
 // * display inline-flex, justify-content, and align-items with its vendor prefixes.
 // @see inflex-stretch-center.test
 @forward "./inflex-stretch-center.test";
+
+// * forwarding the "inflex-stretch-end.test" module.
+// * The "inflex-stretch-end.test" module likely provides a test cases for
+// * display inline-flex, justify-content, and align-items with its vendor prefixes.
+// @see inflex-stretch-end.test
+@forward "./inflex-stretch-end.test";

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-baseline.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-baseline.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-stretch-baseline mixin.
+// * This module tests a inflex-stretch-baseline mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/stretch
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-stretch-baseline (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-stretch" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-stretch-baseline-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-stretch-baseline-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-stretch-baseline-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-stretch-baseline-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-stretch-baseline-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: baseline,
+            -webkit-align-items: baseline,
+            -ms-flex-align: baseline,
+            -moz-align-items: baseline,
+            align-items: baseline,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-stretch-baseline-map {
+    @include describe("[Mixin] inflex-stretch-baseline") {
+        @include it("should output correct inflex-stretch-baseline values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-stretch-baseline(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-center.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-center.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-stretch-center mixin.
+// * This module tests a inflex-stretch-center mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/stretch
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-stretch-center (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-stretch" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-stretch-center-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-stretch-center-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-stretch-center-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-stretch-center-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-stretch-center-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: center,
+            -webkit-align-items: center,
+            -ms-flex-align: center,
+            -moz-align-items: center,
+            align-items: center,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-stretch-center-map {
+    @include describe("[Mixin] inflex-stretch-center") {
+        @include it("should output correct inflex-stretch-center values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-stretch-center(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-end.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-end.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-stretch-end mixin.
+// * This module tests a inflex-stretch-end mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/stretch
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-stretch-end (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-stretch" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-stretch-end-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-stretch-end-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-stretch-end-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-stretch-end-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-stretch-end-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: end,
+            -webkit-align-items: end,
+            -ms-flex-align: end,
+            -moz-align-items: end,
+            align-items: end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-stretch-end-map {
+    @include describe("[Mixin] inflex-stretch-end") {
+        @include it("should output correct inflex-stretch-end values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-stretch-end(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-fend.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-fend.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-stretch-fend mixin.
+// * This module tests a inflex-stretch-fend mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/stretch
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-stretch-fend (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-stretch" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-stretch-fend-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-stretch-fend-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-stretch-fend-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-stretch-fend-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-stretch-fend-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: flex-end,
+            -webkit-align-items: flex-end,
+            -ms-flex-align: flex-end,
+            -moz-align-items: flex-end,
+            align-items: flex-end,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-stretch-fend-map {
+    @include describe("[Mixin] inflex-stretch-fend") {
+        @include it("should output correct inflex-stretch-fend values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-stretch-fend(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-fstart.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-fstart.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-stretch-fstart mixin.
+// * This module tests a inflex-stretch-fstart mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/stretch
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-stretch-fstart (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-stretch" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-stretch-fstart-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-stretch-fstart-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-stretch-fstart-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-stretch-fstart-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-stretch-fstart-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: flex-start,
+            -webkit-align-items: flex-start,
+            -ms-flex-align: flex-start,
+            -moz-align-items: flex-start,
+            align-items: flex-start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-stretch-fstart-map {
+    @include describe("[Mixin] inflex-stretch-fstart") {
+        @include it("should output correct inflex-stretch-fstart values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-stretch-fstart(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-inherit.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-inherit.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-stretch-inh mixin.
+// * This module tests a inflex-stretch-inh mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/stretch
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-stretch-inh (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-stretch" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-stretch-inh-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-stretch-inh-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-stretch-inh-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-stretch-inh-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-stretch-inh-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: inherit,
+            -webkit-align-items: inherit,
+            -ms-flex-align: inherit,
+            -moz-align-items: inherit,
+            align-items: inherit,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-stretch-inh-map {
+    @include describe("[Mixin] inflex-stretch-inh") {
+        @include it("should output correct inflex-stretch-inh values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-stretch-inh(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-normal.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-normal.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-stretch-normal mixin.
+// * This module tests a inflex-stretch-normal mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/stretch
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-stretch-normal (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-stretch" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-stretch-normal-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-stretch-normal-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-stretch-normal-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-stretch-normal-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-stretch-normal-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: normal,
+            -webkit-align-items: normal,
+            -ms-flex-align: normal,
+            -moz-align-items: normal,
+            align-items: normal,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-stretch-normal-map {
+    @include describe("[Mixin] inflex-stretch-normal") {
+        @include it("should output correct inflex-stretch-normal values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-stretch-normal(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-start.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-start.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-stretch-start mixin.
+// * This module tests a inflex-stretch-start mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/stretch
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-stretch-start (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-stretch" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-stretch-start-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-stretch-start-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-stretch-start-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-stretch-start-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-stretch-start-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: start,
+            -webkit-align-items: start,
+            -ms-flex-align: start,
+            -moz-align-items: start,
+            align-items: start,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-stretch-start-map {
+    @include describe("[Mixin] inflex-stretch-start") {
+        @include it("should output correct inflex-stretch-start values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-stretch-start(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-stretch.test.scss
+++ b/tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_inflex-stretch-stretch.test.scss
@@ -1,0 +1,160 @@
+@charset "UTF-8";
+
+// @description
+// * inflex-stretch-stretch mixin.
+// * This module tests a inflex-stretch-stretch mixin.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace inline-flexbox
+
+// @module inline-flexbox/stretch
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.inflex-stretch-stretch (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../../../src/mixins/flex-props/inline-flexbox/in-stretch" as LibMixin;
+
+// stylelint-disable value-no-vendor-prefix
+// stylelint-disable declaration-block-no-duplicate-properties
+// stylelint-disable value-keyword-case
+// stylelint-disable scss/dollar-variable-empty-line-before
+
+$test-cases-inflex-stretch-stretch-map: (
+    ".test-case-1": (
+        selector: ".test-inflex-stretch-stretch-row-mixin",
+        direction: row,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: row,
+            -ms-flex-direction: row,
+            -moz-flex-direction: row,
+            -o-flex-direction: row,
+            flex-direction: row,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-2": (
+        selector: ".test-inflex-stretch-stretch-row-reverse-mixin",
+        direction: row-reverse,
+        expected: (
+            -webkit-box-orient: horizontal,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: row-reverse,
+            -ms-flex-direction: row-reverse,
+            -moz-flex-direction: row-reverse,
+            -o-flex-direction: row-reverse,
+            flex-direction: row-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-3": (
+        selector: ".test-inflex-stretch-stretch-column-mixin",
+        direction: column,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: normal,
+            -webkit-flex-direction: column,
+            -ms-flex-direction: column,
+            -moz-flex-direction: column,
+            -o-flex-direction: column,
+            flex-direction: column,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+    ".test-case-4": (
+        selector: ".test-inflex-stretch-stretch-column-reverse-mixin",
+        direction: column-reverse,
+        expected: (
+            -webkit-box-orient: vertical,
+            -webkit-box-direction: reverse,
+            -webkit-flex-direction: column-reverse,
+            -ms-flex-direction: column-reverse,
+            -moz-flex-direction: column-reverse,
+            -o-flex-direction: column-reverse,
+            flex-direction: column-reverse,
+            -webkit-box-pack: stretch,
+            -webkit-justify-content: stretch,
+            -ms-flex-pack: stretch,
+            -moz-justify-content: stretch,
+            justify-content: stretch,
+            -webkit-box-align: stretch,
+            -webkit-align-items: stretch,
+            -ms-flex-align: stretch,
+            -moz-align-items: stretch,
+            align-items: stretch,
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-inflex-stretch-stretch-map {
+    @include describe("[Mixin] inflex-stretch-stretch") {
+        @include it("should output correct inflex-stretch-stretch values") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.inflex-stretch-stretch(#{map.get($case-data, direction)});
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)} {
+                        display: -webkit-inline-box;
+                        display: -webkit-inline-flex;
+                        display: -ms-inline-flexbox;
+                        display: -moz-inline-box;
+                        display: inline-flex;
+
+                        @each $property, $value in map.get($case-data, expected) {
+                            #{$property}: #{$value};
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `unit test` for `inflex-stretch-center` mixin to handle all `test cases`.
- Add `unit test` for `inflex-stretch-end` mixin to handle all `test cases`.
- Add `unit test` for `inflex-stretch-fend` mixin to handle all `test cases`.
- Add `unit test` for `inflex-stretch-fstart` mixin to handle all `test cases`.
- Add `unit test` for `inflex-stretch-inh` mixin to handle all `test cases`.
- Add `unit test` for `inflex-stretch-normal` mixin to handle all `test cases`.
- Add `unit test` for `inflex-stretch-start` mixin to handle all `test cases`.
- Add `unit test` for `inflex-stretch-stretch` mixin to handle all `test cases`.
- Update `tests/mixins/flex-props/inline-flexbox/inline-flexbox-stretch/_index.scss` to include all files in the current module.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
