### PR TITLE
test(tests): :white_check_mark: add `unit test` for `even-between` mixin

### DIFF
--- a/tests/mixins/children/_even-between.test.scss
+++ b/tests/mixins/children/_even-between.test.scss
@@ -1,0 +1,97 @@
+@charset "UTF-8";
+
+// @description
+// * even-between mixin.
+// * This is a test cases for the even-between mixin.
+
+// @access public
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/Black-Axis/sass-pire
+
+// @namespace children
+
+// @module children/even-between
+
+// @dependencies:
+// * - map.get (SASS function).
+// * - True.describe (mixin function).
+// * - True.it (true mixin).
+// * - True.assert (true mixin).
+// * - True.output (true mixin).
+// * - True.expect (true mixin).
+// * - LibMixin.even-between (mixin).
+
+@use "sass:map";
+@use "true" as *;
+@use "../../../src/mixins/children/even-between" as LibMixin;
+
+$test-cases-even-between-map: (
+    "test-case-1": (
+        selector: ".test-even-between-1",
+        first-num: 4,
+        second-num: 10,
+        expected: (
+            nth-child: "nth-child(even):nth-child(n+4):nth-child(-n+10)",
+        ),
+    ),
+    "test-case-2": (
+        selector: ".test-even-between-2",
+        first-num: 6,
+        second-num: 8,
+        expected: (
+            nth-child: "nth-child(even):nth-child(n+6):nth-child(-n+8)",
+        ),
+    ),
+    "test-case-3": (
+        selector: ".test-even-between-3",
+        first-num: 12,
+        second-num: 100,
+        expected: (
+            nth-child: "nth-child(even):nth-child(n+12):nth-child(-n+100)",
+        ),
+    ),
+    "test-case-4": (
+        selector: ".test-even-between-4",
+        first-num: 12,
+        second-num: 0,
+        expected: (
+            nth-child: "nth-child(even):nth-child(n+12):nth-child(-n+0)",
+        ),
+    ),
+    "test-case-5": (
+        selector: ".test-even-between-5",
+        first-num: 1,
+        second-num: 2,
+        expected: (
+            nth-child: "nth-child(even):nth-child(n+1):nth-child(-n+2)",
+        ),
+    ),
+);
+
+@each $case-name, $case-data in $test-cases-even-between-map {
+    @include describe("[Mixin] even-between for #{$case-name}") {
+        @include it("Should result a selector between two numbers but even children only") {
+            @include assert {
+                @include output {
+                    #{map.get($case-data, selector)} {
+                        @include LibMixin.even-between(map.get($case-data, first-num), map.get($case-data, second-num)) {
+                            --sp-example-even-between: done;
+                        }
+                    }
+                }
+
+                @include expect {
+                    #{map.get($case-data, selector)}:#{map.get(map.get($case-data, expected), nth-child)} {
+                        --sp-example-even-between: done;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/mixins/children/_index.scss
+++ b/tests/mixins/children/_index.scss
@@ -64,3 +64,9 @@
 // * children module.
 // @see odd-between.test
 @forward "odd-between.test";
+
+// * forwarding the "even-between.test" module.
+// * The "even-between.test" module likely provides a test cases for
+// * children module.
+// @see even-between.test
+@forward "even-between.test";


### PR DESCRIPTION
<!-- Please, complete this template with the required information -->

## Issue | Task Number: #
<!-- Write your answer here-->
None

## What does this pull request do?
<!-- Write your answer here-->
- Add `unit test` for `even-between` mixin to handle all `test cases`.
- Update `tests/mixins/children/_index.scss` path to include `even-between` mixin module.

## What is the relevant issue link:
<!-- Write your answer here-->
None

## Screenshot (if applicable)
<!-- Paste screenshot here -->
None

## Any additional information?
<!-- Write your answer here-->
None
